### PR TITLE
Fix service and action interface generation

### DIFF
--- a/rosidl_generator_java/CMakeLists.txt
+++ b/rosidl_generator_java/CMakeLists.txt
@@ -67,6 +67,7 @@ if(BUILD_TESTING)
   set(_deps_library_dirs "")
   list_append_unique(_deps_library_dirs ${CMAKE_CURRENT_BINARY_DIR})
   list_append_unique(_deps_library_dirs ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_java/rosidl_generator_java/msg/)
+  list_append_unique(_deps_library_dirs ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_java/rosidl_generator_java/srv/)
 
   foreach(testsuite ${${PROJECT_NAME}_testsuites})
     ament_add_junit_tests("${PROJECT_NAME}_tests_${testsuite}"

--- a/rosidl_generator_java/cmake/rosidl_generator_java_generate_interfaces.cmake
+++ b/rosidl_generator_java/cmake/rosidl_generator_java_generate_interfaces.cmake
@@ -70,6 +70,10 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
       "${_output_path}/${_parent_folder}/${_idl_name}_Request.java"
       "${_output_path}/${_parent_folder}/${_idl_name}_Response.java"
     )
+    foreach(_typesupport_impl ${_typesupport_impls})
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_Request.ep.${_typesupport_impl}.cpp")
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_Response.ep.${_typesupport_impl}.cpp")
+    endforeach()
   endif()
   # Actions generate extra files
   if(_parent_folder STREQUAL "action")
@@ -78,6 +82,11 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
       "${_output_path}/${_parent_folder}/${_idl_name}_Result.java"
       "${_output_path}/${_parent_folder}/${_idl_name}_Feedback.java"
     )
+    foreach(_typesupport_impl ${_typesupport_impls})
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_Goal.ep.${_typesupport_impl}.cpp")
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_Result.ep.${_typesupport_impl}.cpp")
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_Feedback.ep.${_typesupport_impl}.cpp")
+    endforeach()
   endif()
 
   foreach(_typesupport_impl ${_typesupport_impls})

--- a/rosidl_generator_java/resource/action.cpp.em
+++ b/rosidl_generator_java/resource/action.cpp.em
@@ -1,22 +1,101 @@
 @# Included from rosidl_generator_java/resource/idl.cpp.em
 @{
+import os
+
+from rosidl_cmake import expand_template
 from rosidl_generator_c import idl_structure_type_to_c_include_prefix
 
-action_includes = [
+namespaces = action.namespaced_type.namespaces
+type_name = action.namespaced_type.name
+goal_type_name = action.goal.structure.namespaced_type.name
+result_type_name = action.result.structure.namespaced_type.name
+feedback_type_name = action.feedback.structure.namespaced_type.name
+feedback_message_type_name = action.feedback_message.structure.namespaced_type.name
+send_goal_type_name = action.send_goal_service.namespaced_type.name
+get_result_type_name = action.get_result_service.namespaced_type.name
+
+data = {
+    'package_name': package_name,
+    'output_dir': output_dir,
+    'template_basepath': template_basepath,
+}
+
+# Generate Goal message type
+data.update({'message': action.goal})
+output_file = os.path.join(
+    output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(goal_type_name, typesupport_impl))
+expand_template(
+    'msg.cpp.em',
+    data,
+    output_file)
+
+# Generate Result message type
+data.update({'message': action.result})
+output_file = os.path.join(
+    output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(result_type_name, typesupport_impl))
+expand_template(
+    'msg.cpp.em',
+    data,
+    output_file)
+
+# Generate Feedback message type
+data.update({'message': action.feedback})
+output_file = os.path.join(
+    output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(feedback_type_name, typesupport_impl))
+expand_template(
+    'msg.cpp.em',
+    data,
+    output_file)
+
+# Generate FeedbackMessage message type
+data.update({'message': action.feedback_message})
+output_file = os.path.join(
+    output_dir,
+    *namespaces[1:],
+    '{0}.ep.{1}.cpp'.format(feedback_message_type_name, typesupport_impl))
+expand_template(
+    'msg.cpp.em',
+    data,
+    output_file)
+
+# Generate SendGoal service type
+data.update({'service': action.send_goal_service})
+output_file = os.path.join(
+    output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(send_goal_type_name, typesupport_impl))
+expand_template(
+    'msg.cpp.em',
+    data,
+    output_file)
+
+# Generate SendGoal service type
+data.update({'service': action.get_result_service})
+output_file = os.path.join(
+    output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(get_result_type_name, typesupport_impl))
+expand_template(
+    'msg.cpp.em',
+    data,
+    output_file)
+
+jni_includes = [
+    'jni.h',
+]
+
+rosidl_includes = [
     'rosidl_generator_c/action_type_support_struct.h',
 ]
 }@
-@[for include in action_includes]@
-@[  if include in include_directives]@
-// already included above
-// @
-@[  else]@
-@{include_directives.add(include)}@
-@[  end if]@
+@[for include in jni_includes]@
+#include <@(include)>
+@[end for]@
+
+@[for include in rosidl_includes]@
 #include "@(include)"
 @[end for]@
 
 #include "@(idl_structure_type_to_c_include_prefix(action.namespaced_type)).h"
+
+// Ensure that a jlong is big enough to store raw pointers
+static_assert(sizeof(jlong) >= sizeof(std::intptr_t), "jlong must be able to store pointers");
 
 #ifdef __cplusplus
 extern "C" {

--- a/rosidl_generator_java/resource/action.cpp.em
+++ b/rosidl_generator_java/resource/action.cpp.em
@@ -79,12 +79,18 @@ expand_template(
 jni_includes = [
     'jni.h',
 ]
-
+std_includes = [
+    'cstdint',
+]
 rosidl_includes = [
     'rosidl_generator_c/action_type_support_struct.h',
 ]
 }@
 @[for include in jni_includes]@
+#include <@(include)>
+@[end for]@
+
+@[for include in std_includes]@
 #include <@(include)>
 @[end for]@
 

--- a/rosidl_generator_java/resource/action.cpp.em
+++ b/rosidl_generator_java/resource/action.cpp.em
@@ -75,28 +75,13 @@ expand_template(
     'msg.cpp.em',
     data,
     output_file)
-
-jni_includes = [
-    'jni.h',
-]
-std_includes = [
-    'cstdint',
-]
-rosidl_includes = [
-    'rosidl_generator_c/action_type_support_struct.h',
-]
 }@
-@[for include in jni_includes]@
-#include <@(include)>
-@[end for]@
 
-@[for include in std_includes]@
-#include <@(include)>
-@[end for]@
+#include <jni.h>
 
-@[for include in rosidl_includes]@
-#include "@(include)"
-@[end for]@
+#include <cstdint>
+
+#include "rosidl_generator_c/action_type_support_struct.h"
 
 #include "@(idl_structure_type_to_c_include_prefix(action.namespaced_type)).h"
 

--- a/rosidl_generator_java/resource/idl.cpp.em
+++ b/rosidl_generator_java/resource/idl.cpp.em
@@ -9,102 +9,93 @@
 @#  - package_name (string)
 @#  - interface_path (Path relative to the directory named after the package)
 @#  - content (IdlContent, list of elements, e.g. Messages or Services)
+@#  - output_dir (Path)
+@#  - template_basepath (Path)
+@#  - typesupport_impl (string, the typesupport identifier of the generated code)
 @#######################################################################
 @{
-include_directives = set()
+import os
 
-jni_includes = [
-    'jni.h',
-]
-include_directives.update(jni_includes)
-std_includes = [
-    'cassert',
-    'cstdint',
-    'string',
-]
-include_directives.update(std_includes)
-rosidl_includes = [
-    'rosidl_generator_c/message_type_support_struct.h',
-]
-include_directives.update(rosidl_includes)
-rcljava_includes = [
-    'rcljava_common/exceptions.h',
-    'rcljava_common/signatures.h',
-]
-include_directives.update(rcljava_includes)
-}@
-@[for include in jni_includes]@
-#include <@(include)>
-@[end for]@
+from rosidl_cmake import expand_template
+from rosidl_parser.definition import Action
+from rosidl_parser.definition import Message
+from rosidl_parser.definition import Service
 
-@[for include in std_includes]@
-#include <@(include)>
-@[end for]@
+# jni_package_name = package_name.replace('_', '_1')
 
-@[for include in rosidl_includes]@
-#include "@(include)"
-@[end for]@
-
-@[for include in rcljava_includes]@
-#include "@(include)"
-@[end for]@
-
-// Ensure that a jlong is big enough to store raw pointers
-static_assert(sizeof(jlong) >= sizeof(std::intptr_t), "jlong must be able to store pointers");
-
-using rcljava_common::exceptions::rcljava_throw_exception;
-
-@{
-jni_package_name = package_name.replace('_', '_1')
 }@
 @
 @#######################################################################
 @# Handle messages
 @#######################################################################
 @{
-from rosidl_parser.definition import Message
+data = {
+    'package_name': package_name,
+    # 'jni_package_name': jni_package_name,
+    'output_dir': output_dir,
+    'template_basepath': template_basepath,
+}
+
+for message in content.get_elements_of_type(Message):
+    data.update({'message': message})
+    type_name = message.structure.namespaced_type.name
+    namespaces = message.structure.namespaced_type.namespaces
+    output_file = os.path.join(
+        output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(type_name, typesupport_impl))
+    expand_template(
+        'msg.cpp.em',
+        data,
+        output_file,
+        template_basepath=template_basepath)
 }@
-@[for message in content.get_elements_of_type(Message)]@
-@{
-TEMPLATE(
-    'msg.cpp.em',
-    package_name=package_name,
-    jni_package_name=jni_package_name,
-    message=message,
-    include_directives=include_directives)
-}@
-@[end for]@
 @
 @#######################################################################
 @# Handle services
 @#######################################################################
 @{
-from rosidl_parser.definition import Service
+data = {
+    'package_name': package_name,
+    'interface_path': interface_path,
+    'output_dir': output_dir,
+    'template_basepath': template_basepath,
+    'typesupport_impl': typesupport_impl,
+}
+
+for service in content.get_elements_of_type(Service):
+    data.update({'service': service})
+    type_name = service.namespaced_type.name
+    namespaces = service.namespaced_type.namespaces
+    output_file = os.path.join(
+        output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(type_name, typesupport_impl))
+    expand_template(
+        'srv.cpp.em',
+        data,
+        output_file,
+        template_basepath=template_basepath)
+
 }@
-@[for service in content.get_elements_of_type(Service)]@
-@{
-TEMPLATE(
-    'srv.cpp.em',
-    package_name=package_name,
-    jni_package_name=jni_package_name,
-    service=service,
-    include_directives=include_directives)
-}@
-@[end for]@
 @
 @#######################################################################
 @# Handle actions
 @#######################################################################
 @{
-from rosidl_parser.definition import Action
+data = {
+    'package_name': package_name,
+    'interface_path': interface_path,
+    'output_dir': output_dir,
+    'template_basepath': template_basepath,
+    'typesupport_impl': typesupport_impl,
+}
+
+for action in content.get_elements_of_type(Action):
+    data.update({'action': action})
+    type_name = action.namespaced_type.name
+    namespaces = action.namespaced_type.namespaces
+    output_file = os.path.join(
+        output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(type_name, typesupport_impl))
+    expand_template(
+        'action.cpp.em',
+        data,
+        output_file,
+        template_basepath=template_basepath)
 }@
-@[for action in content.get_elements_of_type(Action)]@
-@{
-TEMPLATE(
-    'action.cpp.em',
-    package_name=package_name,
-    jni_package_name=jni_package_name,
-    action=action,
-    include_directives=include_directives)
-}@
-@[end for]@

--- a/rosidl_generator_java/resource/idl.cpp.em
+++ b/rosidl_generator_java/resource/idl.cpp.em
@@ -21,8 +21,6 @@ from rosidl_parser.definition import Action
 from rosidl_parser.definition import Message
 from rosidl_parser.definition import Service
 
-# jni_package_name = package_name.replace('_', '_1')
-
 }@
 @
 @#######################################################################
@@ -31,7 +29,6 @@ from rosidl_parser.definition import Service
 @{
 data = {
     'package_name': package_name,
-    # 'jni_package_name': jni_package_name,
     'output_dir': output_dir,
     'template_basepath': template_basepath,
 }

--- a/rosidl_generator_java/resource/msg.cpp.em
+++ b/rosidl_generator_java/resource/msg.cpp.em
@@ -79,6 +79,9 @@ for member in message.structure.members:
         include_prefix = idl_structure_type_to_c_include_prefix(type_)
         # TODO(jacobperron): Remove this logic after https://github.com/ros2/rosidl/pull/432 (Foxy)
         # Strip off any service or action suffix
+        # There are several types that actions and services are composed of, but they are included
+        # a common header that is based on the action or service name
+        # ie. there are not separate headers for each type
         if include_prefix.endswith('__request'):
             include_prefix = include_prefix[:-9]
         elif include_prefix.endswith('__response'):

--- a/rosidl_generator_java/resource/msg.cpp.em
+++ b/rosidl_generator_java/resource/msg.cpp.em
@@ -19,22 +19,6 @@ from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import NamespacedType
 
-jni_includes = [
-    'jni.h',
-]
-std_includes = [
-    'cassert',
-    'cstdint',
-    'string',
-]
-rosidl_includes = [
-    'rosidl_generator_c/message_type_support_struct.h',
-]
-rcljava_includes = [
-    'rcljava_common/exceptions.h',
-    'rcljava_common/signatures.h',
-]
-
 msg_normalized_type = '__'.join(message.structure.namespaced_type.namespaced_name())
 msg_jni_type = '/'.join(message.structure.namespaced_type.namespaced_name())
 
@@ -110,21 +94,16 @@ elif message_c_include_prefix.endswith('__feedback'):
     message_c_include_prefix = message_c_include_prefix[:-10]
 }@
 
-@[for include in jni_includes]@
-#include <@(include)>
-@[end for]@
+#include <jni.h>
 
-@[for include in std_includes]@
-#include <@(include)>
-@[end for]@
+#include <cassert>
+#include <cstdint>
+#include <string>
 
-@[for include in rosidl_includes]@
-#include "@(include)"
-@[end for]@
+#include "rosidl_generator_c/message_type_support_struct.h"
 
-@[for include in rcljava_includes]@
-#include "@(include)"
-@[end for]@
+#include "rcljava_common/exceptions.h"
+#include "rcljava_common/signatures.h"
 
 @[for include in member_includes]@
 #include "@(include)"

--- a/rosidl_generator_java/resource/srv.cpp.em
+++ b/rosidl_generator_java/resource/srv.cpp.em
@@ -32,28 +32,13 @@ expand_template(
     'msg.cpp.em',
     data,
     output_file)
-
-jni_includes = [
-    'jni.h',
-]
-std_includes = [
-    'cstdint',
-]
-rosidl_includes = [
-    'rosidl_generator_c/service_type_support_struct.h',
-]
 }@
-@[for include in jni_includes]@
-#include <@(include)>
-@[end for]@
 
-@[for include in std_includes]@
-#include <@(include)>
-@[end for]@
+#include <jni.h>
 
-@[for include in rosidl_includes]@
-#include "@(include)"
-@[end for]@
+#include <cstdint>
+
+#include "rosidl_generator_c/service_type_support_struct.h"
 
 #include "@(idl_structure_type_to_c_include_prefix(service.namespaced_type)).h"
 

--- a/rosidl_generator_java/resource/srv.cpp.em
+++ b/rosidl_generator_java/resource/srv.cpp.em
@@ -36,11 +36,18 @@ expand_template(
 jni_includes = [
     'jni.h',
 ]
+std_includes = [
+    'cstdint',
+]
 rosidl_includes = [
     'rosidl_generator_c/service_type_support_struct.h',
 ]
 }@
 @[for include in jni_includes]@
+#include <@(include)>
+@[end for]@
+
+@[for include in std_includes]@
 #include <@(include)>
 @[end for]@
 

--- a/rosidl_generator_java/rosidl_generator_java/__init__.py
+++ b/rosidl_generator_java/rosidl_generator_java/__init__.py
@@ -204,4 +204,4 @@ def get_jni_signature(type_):
 def get_jni_mangled_name(fully_qualified_name):
     # JNI name mangling:
     # https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#resolving_native_method_names
-    return fully_qualified_name[0].replace('_', '_1') + '_' + '_'.join(fully_qualified_name[1:])
+    return '_'.join(list(map(lambda name: name.replace('_', '_1'), fully_qualified_name)))

--- a/rosidl_generator_java/rosidl_generator_java/__init__.py
+++ b/rosidl_generator_java/rosidl_generator_java/__init__.py
@@ -47,6 +47,7 @@ def generate_java(generator_arguments_file, typesupport_impls):
         mapping = {
           'idl.cpp.em': '%s.ep.{0}.cpp'.format(impl),
         }
+        additional_context.update(typesupport_impl=impl)
         generate_files(
             generator_arguments_file,
             mapping,

--- a/rosidl_generator_java/rosidl_generator_java/__init__.py
+++ b/rosidl_generator_java/rosidl_generator_java/__init__.py
@@ -45,7 +45,7 @@ def generate_java(generator_arguments_file, typesupport_impls):
 
     for impl in typesupport_impls:
         mapping = {
-          'idl.cpp.em': '%s.ep.{0}.cpp'.format(impl),
+          'idl.cpp.em': '_%s.cpp',
         }
         additional_context.update(typesupport_impl=impl)
         generate_files(

--- a/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
+++ b/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
@@ -532,4 +532,73 @@ public class InterfacesTest {
 
     assertEquals(42, unbounded_seq.getAlignmentCheck());
   }
+
+  @Test
+  public final void testBasicTypesService() {
+    rosidl_generator_java.srv.BasicTypes_Request basicTypesRequest =
+      new rosidl_generator_java.srv.BasicTypes_Request();
+    rosidl_generator_java.srv.BasicTypes_Response basicTypesResponse =
+      new rosidl_generator_java.srv.BasicTypes_Response();
+    // Set request fields
+    boolean expectedBool1 = true;
+    basicTypesRequest.setBoolValue(expectedBool1);
+    byte expectedByte1 = 123;
+    basicTypesRequest.setByteValue(expectedByte1);
+    byte expectedChar1 = 'a';
+    basicTypesRequest.setCharValue(expectedChar1);
+    float expectedFloat1 = 12.34f;
+    basicTypesRequest.setFloat32Value(expectedFloat1);
+    double expectedDouble1 = 12.34;
+    basicTypesRequest.setFloat64Value(expectedDouble1);
+    byte expectedInt81 = 123;
+    basicTypesRequest.setInt8Value(expectedInt81);
+    short expectedInt161 = 1230;
+    basicTypesRequest.setInt16Value(expectedInt161);
+    int expectedInt321 = 123000;
+    basicTypesRequest.setInt32Value(expectedInt321);
+    long expectedInt641 = 42949672960L;
+    basicTypesRequest.setInt64Value(expectedInt641);
+
+    // Set response fields
+    boolean expectedBool2 = false;
+    basicTypesResponse.setBoolValue(expectedBool2);
+    byte expectedByte2 = -42;
+    basicTypesResponse.setByteValue(expectedByte2);
+    byte expectedChar2 = ' ';
+    basicTypesResponse.setCharValue(expectedChar2);
+    float expectedFloat2 = -43.21f;
+    basicTypesResponse.setFloat32Value(expectedFloat2);
+    double expectedDouble2 = -43.21;
+    basicTypesResponse.setFloat64Value(expectedDouble2);
+    byte expectedInt82 = -42;
+    basicTypesResponse.setInt8Value(expectedInt82);
+    short expectedInt162 = -420;
+    basicTypesResponse.setInt16Value(expectedInt162);
+    int expectedInt322 = -42000;
+    basicTypesResponse.setInt32Value(expectedInt322);
+    long expectedInt642 = -4200000L;
+    basicTypesResponse.setInt64Value(expectedInt642);
+
+    // Get request fields
+    assertEquals(expectedBool1, basicTypesRequest.getBoolValue());
+    assertEquals(expectedByte1, basicTypesRequest.getByteValue());
+    assertEquals(expectedChar1, basicTypesRequest.getCharValue());
+    assertEquals(expectedFloat1, basicTypesRequest.getFloat32Value(), 0.01f);
+    assertEquals(expectedDouble1, basicTypesRequest.getFloat64Value(), 0.01);
+    assertEquals(expectedInt81, basicTypesRequest.getInt8Value());
+    assertEquals(expectedInt161, basicTypesRequest.getInt16Value());
+    assertEquals(expectedInt321, basicTypesRequest.getInt32Value());
+    assertEquals(expectedInt641, basicTypesRequest.getInt64Value());
+
+    // Get response fields
+    assertEquals(expectedBool2, basicTypesResponse.getBoolValue());
+    assertEquals(expectedByte2, basicTypesResponse.getByteValue());
+    assertEquals(expectedChar2, basicTypesResponse.getCharValue());
+    assertEquals(expectedFloat2, basicTypesResponse.getFloat32Value(), 0.01f);
+    assertEquals(expectedDouble2, basicTypesResponse.getFloat64Value(), 0.01);
+    assertEquals(expectedInt82, basicTypesResponse.getInt8Value());
+    assertEquals(expectedInt162, basicTypesResponse.getInt16Value());
+    assertEquals(expectedInt322, basicTypesResponse.getInt32Value());
+    assertEquals(expectedInt642, basicTypesResponse.getInt64Value());
+  }
 }


### PR DESCRIPTION
Depends on https://github.com/ros2-java/ros2_java/pull/68.
After #68 is merged, I can rebase this branch.

Before, we were not generating code for the messages and services that make up service and action
interfaces.

Due to issues with duplicate definitions caused by instantiating the msg.cpp.em template
multiple times, I've opted to generate separate files for each service, action, and the interfaces
that they are made of. This is similar to what we are doing with the generated Java code.

I've added a test confirming that generated service code can be used. Adding a test for actions is
difficult at the moment due to a circular dependency with action_msgs.