### PR TITLE
rcl_interfaces can't use master

### DIFF
--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -38,7 +38,7 @@ repositories:
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: master
+    version: 0.5.0
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git


### PR DESCRIPTION
use newest master cause 

> Could not find a package configuration file provided by
>   "unique_identifier_msgs"