### PR TITLE
Workaround dependency error when generating test message

### DIFF
--- a/rosidl_generator_java/CMakeLists.txt
+++ b/rosidl_generator_java/CMakeLists.txt
@@ -37,6 +37,8 @@ if(BUILD_TESTING)
   include(cmake/register_java.cmake)
   include(cmake/rosidl_generator_java_get_typesupports.cmake)
 
+  # Trick ament_target_dependencies() into thinking this package has been found
+  set(rosidl_generator_java_FOUND "1")
   set(rosidl_generator_java_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
   rosidl_generator_java_extras(


### PR DESCRIPTION
Otherwise, we get the following CMake error as of ROS 2 Eloquent:

```
  ament_target_dependencies() the passed package name 'rosidl_generator_java'
  was not found before
```