### PR TITLE
Shutdown default context after tests

### DIFF
--- a/rcljava/src/test/java/org/ros2/rcljava/publisher/PublisherTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/publisher/PublisherTest.java
@@ -33,5 +33,6 @@ public class PublisherTest {
     assertEquals(node.getHandle(), publisher.getNodeReference().get().getHandle());
     assertNotEquals(0, publisher.getNodeReference().get().getHandle());
     assertNotEquals(0, publisher.getHandle());
+    RCLJava.shutdown();
   }
 }

--- a/rcljava/src/test/java/org/ros2/rcljava/subscription/SubscriptionTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/subscription/SubscriptionTest.java
@@ -36,5 +36,6 @@ public class SubscriptionTest {
     assertEquals(node.getHandle(), subscription.getNodeReference().get().getHandle());
     assertNotEquals(0, subscription.getNodeReference().get().getHandle());
     assertNotEquals(0, subscription.getHandle());
+    RCLJava.shutdown();
   }
 }

--- a/rcljava/src/test/java/org/ros2/rcljava/timer/TimerTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/timer/TimerTest.java
@@ -79,5 +79,6 @@ public class TimerTest {
     assertTrue(timer.isCanceled());
 
     assertEquals(4, timerCallback.getCounter());
+    RCLJava.shutdown();
   }
 }


### PR DESCRIPTION
This fixes some fatal runtime errors during testing.