### PR TITLE
Add GitHub workflow for Dashing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Install Java
+      run: |
+        sudo apt update -qq
+        sudo apt install -y default-jdk
+    - uses: ros-tooling/setup-ros@0.0.14
+      with:
+        required-ros-distributions: dashing
+    - uses: ros-tooling/action-ros-ci@8d58122
+      with:
+        package-name: rosidl_generator_java rcljava_common rcljava
+        source-ros-binary-installation: dashing
+        vcs-repo-file-url: https://raw.githubusercontent.com/ros2-java/ros2_java/jacob/update_desktop_repos/ros2_java_desktop.repos

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,4 +17,4 @@ jobs:
       with:
         package-name: rosidl_generator_java rcljava_common rcljava
         source-ros-binary-installation: dashing
-        vcs-repo-file-url: https://raw.githubusercontent.com/ros2-java/ros2_java/jacob/update_desktop_repos/ros2_java_desktop.repos
+        vcs-repo-file-url: https://raw.githubusercontent.com/ros2-java/ros2_java/dashing/ros2_java_desktop.repos


### PR DESCRIPTION
Depends on several outstanding PRs for CI to pass: #76 #93 #94

Opening for visibility. Will rebase after the above referenced PRs are merged.

---

This adds a GitHub workflow to build and test ros2_java for Dashing. When we're ready to merge this with the master and branch for Eloquent / Foxy, we can update the workflow file accordingly.

I believe adding jobs for Windows and macOS should be straight forward, which I'll look into adding next.

Similarly, adding jobs for Android builds is on my TODO list.
