### PR TITLE
Remove non-existent dependency on rosidl_typesupport_java

### DIFF
--- a/rcljava/package.xml
+++ b/rcljava/package.xml
@@ -19,7 +19,6 @@
   <build_depend>rmw</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
   <build_depend>rosidl_typesupport_c</build_depend>
-  <build_depend>rosidl_typesupport_java</build_depend>
   <build_export_depend>builtin_interfaces</build_export_depend>
   <build_export_depend>rcl_interfaces</build_export_depend>
   <build_export_depend>rmw</build_export_depend>


### PR DESCRIPTION
The package does not exist.