### PR TITLE
Add example_interfaces to desktop repos file

### DIFF
--- a/ros2_java_desktop.repos
+++ b/ros2_java_desktop.repos
@@ -7,6 +7,10 @@ repositories:
     type: git
     url: https://github.com/ros2/common_interfaces
     version: dashing
+  ros2/example_interfaces:
+    type: git
+    url: https://github.com/ros2/example_interfaces
+    version: dashing
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git

--- a/ros2_java_desktop.repos
+++ b/ros2_java_desktop.repos
@@ -5,11 +5,11 @@ repositories:
     version: master
   ros2/common_interfaces:
     type: git
-    url: https://github.com/ros2/common_interfaces
+    url: https://github.com/ros2/common_interfaces.git
     version: dashing
   ros2/example_interfaces:
     type: git
-    url: https://github.com/ros2/example_interfaces
+    url: https://github.com/ros2/example_interfaces.git
     version: dashing
   ros2/rcl_interfaces:
     type: git
@@ -17,11 +17,11 @@ repositories:
     version: dashing
   ros2/rosidl_defaults:
     type: git
-    url: https://github.com/ros2/rosidl_defaults
+    url: https://github.com/ros2/rosidl_defaults.git
     version: dashing
   ros2/unique_identifier_msgs:
     type: git
-    url: https://github.com/ros2/unique_identifier_msgs
+    url: https://github.com/ros2/unique_identifier_msgs.git
     version: dashing
   ros2_java/ros2_java:
     type: git


### PR DESCRIPTION
This package is required by rcljava_examples.

Also, append .git to repository URLs for consistency