### PR TITLE
Fix action generation

### DIFF
--- a/rosidl_generator_java/resource/action.cpp.em
+++ b/rosidl_generator_java/resource/action.cpp.em
@@ -58,21 +58,45 @@ expand_template(
     data,
     output_file)
 
-# Generate SendGoal service type
-data.update({'service': action.send_goal_service})
-output_file = os.path.join(
-    output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(send_goal_type_name, typesupport_impl))
+# Generate SendGoal message type
+data.update({'msg': action.send_goal_service.request_message})
+output_file = os.path.join(output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(send_goal_type_name, typesupport_impl))
 expand_template(
     'msg.cpp.em',
     data,
     output_file)
 
+# Generate GetResult message type
+data.update({'msg': action.get_result_service.request_message})
+output_file = os.path.join(output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(send_goal_type_name, typesupport_impl))
+expand_template(
+    'msg.cpp.em',
+    data,
+    output_file)
+
+data = {
+    'package_name': package_name,
+    'interface_path': interface_path,
+    'output_dir': output_dir,
+    'template_basepath': template_basepath,
+    'typesupport_impl': typesupport_impl,
+}
+
 # Generate SendGoal service type
+data.update({'service': action.send_goal_service})
+output_file = os.path.join(
+    output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(send_goal_type_name, typesupport_impl))
+expand_template(
+    'srv.cpp.em',
+    data,
+    output_file)
+
+# Generate GetResult service type
 data.update({'service': action.get_result_service})
 output_file = os.path.join(
     output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(get_result_type_name, typesupport_impl))
 expand_template(
-    'msg.cpp.em',
+    'srv.cpp.em',
     data,
     output_file)
 }@


### PR DESCRIPTION
Before, we were not generating code for:
* `<action_goal_name>_SendGoal_Request`
* `<action_goal_name>_SendGoal_Response`
* `<action_goal_name>_GetResult_Request`
* `<action_goal_name>_GetResult_Response`

Before,  code was generated for `<action_goal_name>_Send_Goal`, but this code was duplicate to the code in `<action_goal_name>FeedbackMessage`, which caused unwanted behaviour since it was not meant to be generated there.