### PR TITLE
Add an implementation of the spinAll method to the executors

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -221,6 +221,7 @@ if(BUILD_TESTING)
 
   set(${PROJECT_NAME}_test_sources
     "src/test/java/org/ros2/rcljava/RCLJavaTest.java"
+    "src/test/java/org/ros2/rcljava/SpinTest.java"
     "src/test/java/org/ros2/rcljava/TimeTest.java"
     # "src/test/java/org/ros2/rcljava/client/ClientTest.java"
     "src/test/java/org/ros2/rcljava/node/NodeTest.java"
@@ -233,6 +234,7 @@ if(BUILD_TESTING)
 
   set(${PROJECT_NAME}_testsuites
     "org.ros2.rcljava.RCLJavaTest"
+    "org.ros2.rcljava.SpinTest"
     "org.ros2.rcljava.TimeTest"
     # "org.ros2.rcljava.client.ClientTest"
     "org.ros2.rcljava.node.NodeTest"

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
@@ -328,17 +328,44 @@ public class BaseExecutor {
     return null;
   }
 
-  protected void spinSome() {
-    AnyExecutable anyExecutable = getNextExecutable();
-    if (anyExecutable == null) {
-      waitForWork(0);
-      do {
-        anyExecutable = getNextExecutable();
-        if (anyExecutable != null) {
-          executeAnyExecutable(anyExecutable);
-        }
-      } while (anyExecutable != null);
+  private boolean maxDurationNotElapsed(long maxDurationNs, long startNs) {
+    long nowNs = System.nanoTime();
+    if (maxDurationNs == 0) {
+      // told to spin forever if need be
+      return true;
+    } else if (nowNs - startNs < maxDurationNs) {
+      // told to spin only for some maximum amount of time
+      return true;
     }
+    // spun too long
+    return false;
+  }
+
+  private void spinSomeImpl(long maxDurationNs, boolean exhaustive) {
+    long startNs = System.nanoTime();
+    boolean workAvailable = false;
+    while (RCLJava.ok() && maxDurationNotElapsed(maxDurationNs, startNs)) {
+      if (!workAvailable) {
+        waitForWork(0);
+      }
+      AnyExecutable anyExecutable = getNextExecutable();
+      if (anyExecutable != null) {
+        executeAnyExecutable(anyExecutable);
+      } else {
+        if (!workAvailable || !exhaustive) {
+          break;
+        }
+        workAvailable = false;
+      }
+    }
+  }
+
+  protected void spinSome(long maxDurationNs) {
+    spinSomeImpl(maxDurationNs, false);
+  }
+
+  protected void spinAll(long maxDurationNs) {
+    spinSomeImpl(maxDurationNs, true);
   }
 
   protected void spinOnce(long timeout) {

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/Executor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/Executor.java
@@ -18,7 +18,9 @@ package org.ros2.rcljava.executors;
 import org.ros2.rcljava.node.ComposableNode;
 
 public interface Executor {
-  public void spin();
+  public void addNode(ComposableNode node);
+
+  public void removeNode(ComposableNode node);
 
   public void spinOnce();
 
@@ -26,7 +28,9 @@ public interface Executor {
 
   public void spinSome();
 
-  public void addNode(ComposableNode node);
+  public void spinSome(long maxDurationNs);
 
-  public void removeNode(ComposableNode node);
+  public void spinAll(long maxDurationNs);
+
+  public void spin();
 }

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/MultiThreadedExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/MultiThreadedExecutor.java
@@ -56,7 +56,15 @@ public class MultiThreadedExecutor implements Executor {
   }
 
   public void spinSome() {
-    this.baseExecutor.spinSome();
+    this.spinSome(0);
+  }
+
+  public void spinSome(long maxDurationNs) {
+    this.baseExecutor.spinSome(maxDurationNs);
+  }
+
+  public void spinAll(long maxDurationNs) {
+    this.baseExecutor.spinAll(maxDurationNs);
   }
 
   public void spin() {

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/SingleThreadedExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/SingleThreadedExecutor.java
@@ -39,7 +39,15 @@ public class SingleThreadedExecutor implements Executor {
   }
 
   public void spinSome() {
-    this.baseExecutor.spinSome();
+    this.spinSome(0);
+  }
+
+  public void spinSome(long maxDurationNs) {
+    this.baseExecutor.spinSome(maxDurationNs);
+  }
+
+  public void spinAll(long maxDurationNs) {
+    this.baseExecutor.spinAll(maxDurationNs);
   }
 
   public void spin() {

--- a/rcljava/src/test/java/org/ros2/rcljava/SpinTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/SpinTest.java
@@ -44,8 +44,6 @@ public class SpinTest {
     public void call() {
       this.counter++;
       try {
-        // The timer is configured to wake up after 100 milliseconds, so wait 200
-        // which should be enough to make it trigger.
         Thread.sleep(timeToSleepMs);
       } catch (InterruptedException ex) {
         // We do nothing on exception here; if we didn't wait long enough, then

--- a/rcljava/src/test/java/org/ros2/rcljava/SpinTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/SpinTest.java
@@ -1,0 +1,335 @@
+/* Copyright 2020 Open Source Robotics Foundation, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ros2.rcljava;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.ros2.rcljava.RCLJava;
+import org.ros2.rcljava.concurrent.Callback;
+import org.ros2.rcljava.executors.Executor;
+import org.ros2.rcljava.executors.SingleThreadedExecutor;
+import org.ros2.rcljava.node.ComposableNode;
+import org.ros2.rcljava.node.Node;
+import org.ros2.rcljava.timer.WallTimer;
+
+public class SpinTest {
+  public static class TimerCallback implements Callback {
+    private int counter;
+    private final long timeToSleepMs;
+
+    TimerCallback(long sleepTimeMs) {
+      timeToSleepMs = sleepTimeMs;
+    }
+
+    public void call() {
+      this.counter++;
+      try {
+        // The timer is configured to wake up after 100 milliseconds, so wait 200
+        // which should be enough to make it trigger.
+        Thread.sleep(timeToSleepMs);
+      } catch (InterruptedException ex) {
+        // We do nothing on exception here; if we didn't wait long enough, then
+        // the assert below will fail
+      }
+    }
+
+    public int getCounter() {
+      return this.counter;
+    }
+  }
+
+  @BeforeClass
+  public static void setupOnce() throws Exception {
+    RCLJava.rclJavaInit();
+  }
+
+  @AfterClass
+  public static void tearDownOnce() {
+    RCLJava.shutdown();
+  }
+
+  @Test
+  public final void testSpinOnce() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_once_node");
+    TimerCallback timerCallback = new TimerCallback(0);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    executor.spinOnce();
+    assertEquals(1, timerCallback.getCounter());
+  }
+
+  @Test
+  public final void testSpinOnceTimeout() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_once_timeout");
+    TimerCallback timerCallback = new TimerCallback(0);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    executor.spinOnce(200*1000*1000);
+    assertEquals(1, timerCallback.getCounter());
+  }
+
+  @Test
+  public final void testSpinOnceTimeoutTooShort() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_once_timeout_too_short_node");
+    TimerCallback timerCallback = new TimerCallback(0);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    executor.spinOnce(50*1000*1000);
+    assertEquals(0, timerCallback.getCounter());
+  }
+
+  @Test
+  public final void testSpinSome() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_some_node");
+    TimerCallback timerCallback = new TimerCallback(0);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    try {
+      // The timer is configured to wake up after 100 milliseconds, so wait 200
+      // which should be enough to make it trigger.
+      Thread.sleep(200);
+    } catch (InterruptedException ex) {
+      // We do nothing on exception here; if we didn't wait long enough, then
+      // the assert below will fail
+    }
+    executor.spinSome();
+    assertEquals(1, timerCallback.getCounter());
+  }
+
+  @Test
+  public final void testSpinSomeMaxDuration() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_some_max_duration_node");
+    TimerCallback timerCallback = new TimerCallback(0);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    try {
+      // The timer is configured to wake up after 100 milliseconds, so wait 200
+      // which should be enough to make it trigger.
+      Thread.sleep(200);
+    } catch (InterruptedException ex) {
+      // We do nothing on exception here; if we didn't wait long enough, then
+      // the assert below will fail
+    }
+    executor.spinSome(100*1000*1000);
+    assertEquals(1, timerCallback.getCounter());
+  }
+
+  @Test
+  public final void testSpinSomeMaxDurationMultipleTimers() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_some_max_duration_multiple_timers_node");
+    TimerCallback timerCallback = new TimerCallback(200);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    WallTimer timer2 = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+    assertNotEquals(0, timer2.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    try {
+      // The timer is configured to wake up after 100 milliseconds, so wait 200
+      // which should be enough to make it trigger.
+      Thread.sleep(200);
+    } catch (InterruptedException ex) {
+      // We do nothing on exception here; if we didn't wait long enough, then
+      // the assert below will fail
+    }
+    executor.spinSome(400*1000*1000);
+    assertEquals(2, timerCallback.getCounter());
+  }
+
+  @Test
+  public final void testSpinSomeMaxDurationTooShortMultipleTimers() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_some_max_duration_too_short_node");
+    TimerCallback timerCallback = new TimerCallback(200);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    WallTimer timer2 = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+    assertNotEquals(0, timer2.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    try {
+      // The timer is configured to wake up after 100 milliseconds, so wait 200
+      // which should be enough to make it trigger.
+      Thread.sleep(200);
+    } catch (InterruptedException ex) {
+      // We do nothing on exception here; if we didn't wait long enough, then
+      // the assert below will fail
+    }
+    executor.spinSome(100*1000*1000);
+    assertEquals(1, timerCallback.getCounter());
+  }
+
+  @Test
+  public final void testSpinAll() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_all_node");
+    TimerCallback timerCallback = new TimerCallback(0);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    try {
+      // The timer is configured to wake up after 100 milliseconds, so wait 200
+      // which should be enough to make it trigger.
+      Thread.sleep(200);
+    } catch (InterruptedException ex) {
+      // We do nothing on exception here; if we didn't wait long enough, then
+      // the assert below will fail
+    }
+
+    executor.spinAll(100*1000*1000);
+    assertEquals(1, timerCallback.getCounter());
+  }
+
+  @Test
+  public final void testSpinAllMaxDurationMultipleTimers() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_all_max_duration_multiple_timers_node");
+    TimerCallback timerCallback = new TimerCallback(200);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    WallTimer timer2 = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+    assertNotEquals(0, timer2.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    try {
+      // The timer is configured to wake up after 100 milliseconds, so wait 200
+      // which should be enough to make it trigger.
+      Thread.sleep(200);
+    } catch (InterruptedException ex) {
+      // We do nothing on exception here; if we didn't wait long enough, then
+      // the assert below will fail
+    }
+    executor.spinAll(400*1000*1000);
+    assertEquals(2, timerCallback.getCounter());
+  }
+
+  @Test
+  public final void testSpinAllMaxDurationTooShortMultipleTimers() {
+    Executor executor = new SingleThreadedExecutor();
+    final Node node = RCLJava.createNode("spin_all_max_duration_too_short_node");
+    TimerCallback timerCallback = new TimerCallback(200);
+    WallTimer timer = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    WallTimer timer2 = node.createWallTimer(100, TimeUnit.MILLISECONDS, timerCallback);
+    assertNotEquals(0, timer.getHandle());
+    assertNotEquals(0, timer2.getHandle());
+
+    ComposableNode composableNode = new ComposableNode() {
+      public Node getNode() {
+        return node;
+      }
+    };
+
+    executor.addNode(composableNode);
+
+    try {
+      // The timer is configured to wake up after 100 milliseconds, so wait 200
+      // which should be enough to make it trigger.
+      Thread.sleep(200);
+    } catch (InterruptedException ex) {
+      // We do nothing on exception here; if we didn't wait long enough, then
+      // the assert below will fail
+    }
+    executor.spinAll(100*1000*1000);
+    assertEquals(1, timerCallback.getCounter());
+  }
+}


### PR DESCRIPTION
This is detailed more in the first commit; here's a copy of that commit message:

spinAll() differs from spinSome() in how it looks at ready
executables.  spinSome() collects a list of ready
executables once at the beginning of execution, and then
executes each one until a timeout.  spinAll() will continually
collect new executables, executing each one until a timeout.

This is basically a direct port from the rclcpp version of
the method with the same name.

The second commit adds tests for spinOnce, spinSome, and spinAll.