### PR TITLE
Update copyright notices and update AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,8 @@
+# This is the list of ros2-java's contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
 Esteve Fernandez <esteve@apache.org> https://github.com/esteve
+Open Source Robotics Foundation, Inc.

--- a/LICENSE
+++ b/LICENSE
@@ -177,6 +177,7 @@
    END OF TERMS AND CONDITIONS
 
    Copyright 2016-2017 Esteve Fernandez
+   Copyright 2019 the ros2-java contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,6 @@
 ros2_java
 Copyright 2016-2017 Esteve Fernandez (esteve@apache.org)
+Copyright 2019 the ros2-java contributors
 
 This product includes software developed by
 Esteve Fernandez (esteve@apache.org)

--- a/ament_cmake_export_jars/ament_cmake_export_jars-extras.cmake
+++ b/ament_cmake_export_jars/ament_cmake_export_jars-extras.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2016-2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ament_cmake_export_jars/cmake/ament_cmake_export_jars_package_hook.cmake
+++ b/ament_cmake_export_jars/cmake/ament_cmake_export_jars_package_hook.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2016-2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ament_cmake_export_jars/cmake/ament_export_jars.cmake
+++ b/ament_cmake_export_jars/cmake/ament_export_jars.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2016-2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ament_cmake_export_jni_libraries/ament_cmake_export_jni_libraries-extras.cmake
+++ b/ament_cmake_export_jni_libraries/ament_cmake_export_jni_libraries-extras.cmake
@@ -1,4 +1,4 @@
-# Copyright 2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ament_cmake_export_jni_libraries/cmake/ament_cmake_export_jni_libraries_package_hook.cmake
+++ b/ament_cmake_export_jni_libraries/cmake/ament_cmake_export_jni_libraries_package_hook.cmake
@@ -1,4 +1,4 @@
-# Copyright 2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ament_cmake_export_jni_libraries/cmake/ament_export_jni_libraries.cmake
+++ b/ament_cmake_export_jni_libraries/cmake/ament_export_jni_libraries.cmake
@@ -1,4 +1,4 @@
-# Copyright 2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_RCLJava.h
+++ b/rcljava/include/org_ros2_rcljava_RCLJava.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_Time.h
+++ b/rcljava/include/org_ros2_rcljava_Time.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2017-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_client_ClientImpl.h
+++ b/rcljava/include/org_ros2_rcljava_client_ClientImpl.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_contexts_ContextImpl.h
+++ b/rcljava/include/org_ros2_rcljava_contexts_ContextImpl.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2019 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_executors_BaseExecutor.h
+++ b/rcljava/include/org_ros2_rcljava_executors_BaseExecutor.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2017-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_node_NodeImpl.h
+++ b/rcljava/include/org_ros2_rcljava_node_NodeImpl.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_publisher_PublisherImpl.h
+++ b/rcljava/include/org_ros2_rcljava_publisher_PublisherImpl.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_service_ServiceImpl.h
+++ b/rcljava/include/org_ros2_rcljava_service_ServiceImpl.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_subscription_SubscriptionImpl.h
+++ b/rcljava/include/org_ros2_rcljava_subscription_SubscriptionImpl.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_time_Clock.h
+++ b/rcljava/include/org_ros2_rcljava_time_Clock.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2019 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/include/org_ros2_rcljava_timer_WallTimerImpl.h
+++ b/rcljava/include/org_ros2_rcljava_timer_WallTimerImpl.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2017-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_RCLJava.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_RCLJava.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_Time.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_Time.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2017-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_client_ClientImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_client_ClientImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_contexts_ContextImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_contexts_ContextImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2019 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_executors_BaseExecutor.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_executors_BaseExecutor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2017-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_node_NodeImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_node_NodeImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_publisher_PublisherImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_publisher_PublisherImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_service_ServiceImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_service_ServiceImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_subscription_SubscriptionImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_subscription_SubscriptionImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_time_Clock.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_time_Clock.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2019 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/cpp/org_ros2_rcljava_timer_WallTimerImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_timer_WallTimerImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2017-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/RCLJava.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/Time.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/Time.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/client/Client.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/client/Client.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/client/ClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/client/ClientImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/concurrent/Callback.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/concurrent/Callback.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/concurrent/RCLFuture.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/concurrent/RCLFuture.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/consumers/BiConsumer.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/consumers/BiConsumer.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/consumers/Consumer.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/consumers/Consumer.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/consumers/TriConsumer.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/consumers/TriConsumer.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/contexts/Context.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/contexts/Context.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Open Source Robotics Foundation, Inc.
+/* Copyright 2019 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/contexts/ContextImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/contexts/ContextImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Open Source Robotics Foundation, Inc.
+/* Copyright 2019 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/AnyExecutable.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/AnyExecutable.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/Executor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/Executor.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/MultiThreadedExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/MultiThreadedExecutor.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/executors/SingleThreadedExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/SingleThreadedExecutor.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/node/BaseComposableNode.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/BaseComposableNode.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/node/ComposableNode.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/ComposableNode.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/package-info.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/package-info.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterNames.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterNames.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterType.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterType.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterVariant.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterVariant.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClient.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClient.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClient.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClient.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClientImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterService.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterService.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterServiceImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterServiceImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/publisher/Publisher.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/publisher/Publisher.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/publisher/PublisherImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/publisher/PublisherImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/qos/QoSProfile.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/qos/QoSProfile.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/qos/policies/Durability.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/qos/policies/Durability.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/qos/policies/History.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/qos/policies/History.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/qos/policies/QoSPolicy.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/qos/policies/QoSPolicy.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/qos/policies/Reliability.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/qos/policies/Reliability.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/service/RMWRequestId.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/service/RMWRequestId.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/service/Service.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/service/Service.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/service/ServiceImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/service/ServiceImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/subscription/Subscription.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/subscription/Subscription.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/subscription/SubscriptionImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/time/Clock.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/time/Clock.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Open Source Robotics Foundation, Inc.
+/* Copyright 2019 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/time/ClockType.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/time/ClockType.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/timer/Timer.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/timer/Timer.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/timer/WallTimer.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/timer/WallTimer.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/main/java/org/ros2/rcljava/timer/WallTimerImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/timer/WallTimerImpl.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/test/java/org/ros2/rcljava/RCLJavaTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/RCLJavaTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/test/java/org/ros2/rcljava/TimeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/TimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/test/java/org/ros2/rcljava/publisher/PublisherTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/publisher/PublisherTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/test/java/org/ros2/rcljava/subscription/SubscriptionTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/subscription/SubscriptionTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava/src/test/java/org/ros2/rcljava/timer/TimerTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/timer/TimerTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava_common/cmake/Modules/CrossCompilingExtra.cmake
+++ b/rcljava_common/cmake/Modules/CrossCompilingExtra.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2016-2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rcljava_common/cmake/Modules/JavaExtra.cmake
+++ b/rcljava_common/cmake/Modules/JavaExtra.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2016-2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rcljava_common/include/rcljava_common/exceptions.hpp
+++ b/rcljava_common/include/rcljava_common/exceptions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava_common/include/rcljava_common/signatures.hpp
+++ b/rcljava_common/include/rcljava_common/signatures.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava_common/include/rcljava_common/visibility_control.hpp
+++ b/rcljava_common/include/rcljava_common/visibility_control.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava_common/rcljava_cmake_module-extras.cmake.in
+++ b/rcljava_common/rcljava_cmake_module-extras.cmake.in
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2016-2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rcljava_common/src/main/cpp/rcljava_common.cpp
+++ b/rcljava_common/src/main/cpp/rcljava_common.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+// Copyright 2016-2018 the ros2-java contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcljava_common/src/main/java/org/ros2/rcljava/common/JNIUtils.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/common/JNIUtils.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava_common/src/main/java/org/ros2/rcljava/common/package-info.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/common/package-info.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava_common/src/main/java/org/ros2/rcljava/exceptions/RCLException.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/exceptions/RCLException.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava_common/src/main/java/org/ros2/rcljava/exceptions/RCLReturn.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/exceptions/RCLReturn.java
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2017-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ActionDefinition.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ActionDefinition.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Open Source Robotics Foundation, Inc.
+/* Copyright 2019 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/Disposable.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/Disposable.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/MessageDefinition.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/MessageDefinition.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ServiceDefinition.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ServiceDefinition.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rosidl_generator_java/cmake/custom_command.cmake
+++ b/rosidl_generator_java/cmake/custom_command.cmake
@@ -1,4 +1,4 @@
-# Copyright 2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rosidl_generator_java/cmake/register_java.cmake
+++ b/rosidl_generator_java/cmake/register_java.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2016-2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rosidl_generator_java/cmake/rosidl_generator_java_generate_interfaces.cmake
+++ b/rosidl_generator_java/cmake/rosidl_generator_java_generate_interfaces.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Esteve Fernandez <esteve@apache.org>
+# Copyright 2016-2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rosidl_generator_java/cmake/rosidl_generator_java_get_typesupports.cmake
+++ b/rosidl_generator_java/cmake/rosidl_generator_java_get_typesupports.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016-2017 Open Source Robotics Foundation, Inc.
+# Copyright 2016-2017 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rosidl_generator_java/rosidl_generator_java/__init__.py
+++ b/rosidl_generator_java/rosidl_generator_java/__init__.py
@@ -1,5 +1,4 @@
-# Copyright 2016-2017 Esteve Fernandez <esteve@apache.org>
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2016-2019 the ros2-java contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
+++ b/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2016-2018 Esteve Fernandez <esteve@apache.org>
+/* Copyright 2016-2018 the ros2-java contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Following our discussion in https://github.com/ros2-java/ros2_java/pull/117#discussion_r448350234, I've updated all of the copyright notices to read "Copyright <year> the ros2-java contributors".

I've also updated the AUTHORS file, inspired by https://opensource.google/docs/releasing/authors/.
@esteve Let me know if you prefer a separate CONTRIBUTORS file instead of the change to the AUTHORS file.

This is targeting the `dashing` branch; I'll include this change in the [fast-forward](https://github.com/ros2-java/ros2_java/pull/117) to `master` after this is merged.