### PR TITLE
Update Android instructions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup sources for ROS 2
       run: |
         sudo apt-get update && sudo apt-get install -y curl gnupg2 lsb-release
-        curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+        curl -sL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
         sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
     - name: Install colcon
       run: |
@@ -43,13 +43,18 @@ jobs:
       run: |
         mkdir -p ros2_java_ws/src
         cd ros2_java_ws
-        curl -skL https://raw.githubusercontent.com/ros2-java/ros2_java/jacob/android_instructions/ros2_java_android.repos | vcs import src
+        curl -sL https://raw.githubusercontent.com/ros2-java/ros2_java/jacob/android_instructions/ros2_java_android.repos | vcs import src
+    - name: Install Android NDK
+      run: |
+        curl -LO https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
+        unzip android-ndk-r21d-linux-x86_64.zip
     - name: Build ros2_java for Android
       run: |
         export PYTHON3_EXEC="$( which python3 )"
         export ANDROID_ABI=armeabi-v7a
         export ANDROID_NATIVE_API_LEVEL=android-21
         export ANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-clang
+        export ANDROID_NDK=${PWD}/android-ndk-r21d
 
         cd ros2_java_ws
         colcon build \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,9 +36,9 @@ jobs:
         sudo apt-get update && sudo apt-get install -y curl gnupg2 lsb-release
         curl -sL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
         sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
-    - name: Install colcon
+    - name: Install ROS 2 dependencies
       run: |
-        sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions python3-vcstool
+        sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions python3-vcstool python3-lark-parser
     - name: Fetch VCS repo file
       run: |
         mkdir -p ros2_java_ws/src

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,6 +61,7 @@ jobs:
         cd ros2_java_ws
         colcon build \
           --packages-ignore cyclonedds rcl_logging_log4cxx rosidl_generator_py \
+          --packages-up-to ros2_listener_android ros2_talker_android \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
           -DPYTHON_LIBRARY=${PYTHON3_LIBRARY} \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,7 +58,7 @@ jobs:
 
         cd ros2_java_ws
         colcon build \
-          --packages-skip test_msgs osrf_testing_tools_cpp \
+          --packages-skip test_msgs \
           --packages-up-to rcljava \
           --cmake-args \
           -DBUILD_TESTING=OFF \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
         sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
     - name: Install colcon
       run: |
-        sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions
+        sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions python3-vcstool
     - name: Fetch VCS repo file
       run: |
         mkdir -p ros2_java_ws/src

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,6 +61,7 @@ jobs:
           --packages-skip test_msgs \
           --packages-up-to rcljava \
           --cmake-args \
+          -DBUILD_TESTING=OFF \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
           -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
           -DANDROID_FUNCTION_LEVEL_LINKING=OFF \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,7 +61,6 @@ jobs:
         cd ros2_java_ws
         colcon build \
           --packages-ignore cyclonedds rcl_logging_log4cxx rosidl_generator_py \
-          --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
           -DPYTHON_LIBRARY=${PYTHON3_LIBRARY} \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,9 +26,19 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y default-jdk
-    - uses: ros-tooling/setup-ros@0.0.14
-      with:
-        required-ros-distributions: dashing
+    - name: Setup locale for ROS 2
+      run: |
+        sudo locale-gen en_US en_US.UTF-8
+        sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+        export LANG=en_US.UTF-8
+    - name: Setup sources for ROS 2
+      run: |
+        sudo apt-get update && sudo apt-get install -y curl gnupg2 lsb-release
+        curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+        sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+    - name: Install colcon
+      run: |
+        sudo apt-get update && sudo apt-get install -y python3-colcon3-common-extensions
     - name: Fetch VCS repo file
       run: |
         mkdir -p ros2_java_ws/src

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         package-name: rosidl_generator_java rcljava_common rcljava
         source-ros-binary-installation: dashing
-        vcs-repo-file-url: https://raw.githubusercontent.com/ros2-java/ros2_java/dashing/ros2_java_desktop.repos
+        vcs-repo-file-url: ${{ github.workspace }}/ros2_java_desktop.repos
 
   build_android:
     runs-on: ubuntu-18.04
@@ -51,7 +51,7 @@ jobs:
       run: |
         mkdir -p ros2_java_ws/src
         cd ros2_java_ws
-        curl -sL https://raw.githubusercontent.com/ros2-java/ros2_java/jacob/android_instructions/ros2_java_android.repos | vcs import src
+        curl -sL file://${{ github.workspace }}/ros2_java_android.repos | vcs import src
     - name: Build ros2_java for Android
       run: |
         export PYTHON3_EXEC="$( which python3 )"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,7 +58,7 @@ jobs:
 
         cd ros2_java_ws
         colcon build \
-          --packages-skip test_msgs \
+          --packages-skip test_msgs cyclonedds rmw_cyclonedds \
           --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,13 +13,9 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.14
       with:
         required-ros-distributions: dashing
-    - name: Install colcon extensions for Gradle
-      run: |
-        sudo pip3 install git+git://github.com/colcon/colcon-gradle.git
-        sudo pip3 install git+git://github.com/colcon/colcon-ros-gradle.git
     - uses: ros-tooling/action-ros-ci@8d58122
       with:
-        package-name: rosidl_generator_java rcljava_common rcljava rcljava_examples
+        package-name: rosidl_generator_java rcljava_common rcljava
         source-ros-binary-installation: dashing
         vcs-repo-file-url: https://raw.githubusercontent.com/ros2-java/ros2_java/dashing/ros2_java_desktop.repos
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,11 +49,14 @@ jobs:
       run: |
         curl -LO https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
         unzip android-ndk-r21d-linux-x86_64.zip
-    - name: Fetch VCS repo file
+    - name: Setup workspace with VCS repo file
       run: |
         mkdir -p ros2_java_ws/src
         cd ros2_java_ws
         curl -sL file://${{ github.workspace }}/ros2_java_android.repos | vcs import src
+        # Use checked out version of ros2_java
+        rm -rf src/ros2_java/ros2_java
+        ln --symbolic ${{ github.workspace }} src/ros2_java
     - name: Build ros2_java for Android
       run: |
         export PYTHON3_EXEC="$( which python3 )"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,9 +13,13 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.14
       with:
         required-ros-distributions: dashing
+    - name: Install colcon extensions for Gradle
+      run: |
+        sudo pip3 install git+git://github.com/colcon/colcon-gradle.git
+        sudo pip3 install git+git://github.com/colcon/colcon-ros-gradle.git
     - uses: ros-tooling/action-ros-ci@8d58122
       with:
-        package-name: rosidl_generator_java rcljava_common rcljava
+        package-name: rosidl_generator_java rcljava_common rcljava rcljava_examples
         source-ros-binary-installation: dashing
         vcs-repo-file-url: https://raw.githubusercontent.com/ros2-java/ros2_java/dashing/ros2_java_desktop.repos
 
@@ -39,6 +43,10 @@ jobs:
     - name: Install ROS 2 dependencies
       run: |
         sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions python3-vcstool python3-lark-parser python3-dev
+    - name: Install colcon extensions for Gradle
+      run: |
+        sudo pip3 install git+git://github.com/colcon/colcon-gradle.git
+        sudo pip3 install git+git://github.com/colcon/colcon-ros-gradle.git
     - name: Fetch VCS repo file
       run: |
         mkdir -p ros2_java_ws/src

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,7 +61,6 @@ jobs:
           --packages-skip test_msgs \
           --packages-up-to rcljava \
           --cmake-args \
-          -DBUILD_TESTING=OFF \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
           -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
           -DANDROID_FUNCTION_LEVEL_LINKING=OFF \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Java
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y default-jdk
+        sudo apt-get install -y default-jdk gradle
     - uses: ros-tooling/setup-ros@0.0.14
       with:
         required-ros-distributions: dashing

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -60,7 +60,7 @@ jobs:
 
         cd ros2_java_ws
         colcon build \
-          --packages-skip test_msgs cyclonedds cyclonedds_cmake_module rmw_cyclonedds_cpp rcl_logging_log4cxx \
+          --packages-ignore cyclonedds rcl_logging_log4cxx rosidl_generator_py \
           --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -60,7 +60,7 @@ jobs:
 
         cd ros2_java_ws
         colcon build \
-          --packages-skip test_msgs cyclonedds rmw_cyclonedds rcl_logging_log4cxx \
+          --packages-skip test_msgs cyclonedds cyclonedds_cmake_module rmw_cyclonedds_cpp rcl_logging_log4cxx \
           --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,6 +51,8 @@ jobs:
     - name: Build ros2_java for Android
       run: |
         export PYTHON3_EXEC="$( which python3 )"
+        export PYTHON3_LIBRARY="$( ${PYTHON3_EXEC} -c 'import os.path; from distutils import sysconfig; print(os.path.realpath(os.path.join(sysconfig.get_config_var("LIBPL"), sysconfig.get_config_var("LDLIBRARY"))))' )"
+        export PYTHON3_INCLUDE_DIR="$( ${PYTHON3_EXEC} -c 'from distutils import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))' )"
         export ANDROID_ABI=armeabi-v7a
         export ANDROID_NATIVE_API_LEVEL=android-21
         export ANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-clang
@@ -62,6 +64,8 @@ jobs:
           --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
+          -DPYTHON_LIBRARY=${PYTHON3_LIBRARY} \
+          -DPYTHON_INCLUDE_DIR=${PYTHON3_INCLUDE_DIR} \
           -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
           -DANDROID_FUNCTION_LEVEL_LINKING=OFF \
           -DANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL} \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
         sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
     - name: Install ROS 2 dependencies
       run: |
-        sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions python3-vcstool python3-lark-parser
+        sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions python3-vcstool python3-lark-parser python3-dev
     - name: Fetch VCS repo file
       run: |
         mkdir -p ros2_java_ws/src

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,9 @@ jobs:
         export ANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-clang
 
         cd ros2_java_ws
-        colcon build --packages-skip test_msgs \
+        colcon build \
+          --packages-skip test_msgs \
+          --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
           -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y default-jdk gradle
+    - uses: actions/checkout@v2
     - uses: ros-tooling/setup-ros@0.0.14
       with:
         required-ros-distributions: dashing
@@ -26,6 +27,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y default-jdk gradle
+    - uses: actions/checkout@v2
     - name: Setup locale for ROS 2
       run: |
         sudo locale-gen en_US en_US.UTF-8

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
     - name: Install Java
       run: |
-        sudo apt update -qq
-        sudo apt install -y default-jdk
+        sudo apt-get update -qq
+        sudo apt-get install -y default-jdk
     - uses: ros-tooling/setup-ros@0.0.14
       with:
         required-ros-distributions: dashing
@@ -18,3 +18,39 @@ jobs:
         package-name: rosidl_generator_java rcljava_common rcljava
         source-ros-binary-installation: dashing
         vcs-repo-file-url: https://raw.githubusercontent.com/ros2-java/ros2_java/dashing/ros2_java_desktop.repos
+
+  build_android:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Install Java
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y default-jdk
+    - uses: ros-tooling/setup-ros@0.0.14
+      with:
+        required-ros-distributions: dashing
+    - name: Fetch VCS repo file
+      run: |
+        mkdir -p ros2_java_ws/src
+        cd ros2_java_ws
+        curl -skL https://raw.githubusercontent.com/ros2-java/ros2_java/jacob/android_instructions/ros2_android_desktop.repos | vcs import src
+    - name: Build ros2_java for Android
+      run: |
+        export PYTHON3_EXEC="$( which python3 )"
+        export ANDROID_ABI=armeabi-v7a
+        export ANDROID_NATIVE_API_LEVEL=android-21
+        export ANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-clang
+
+        cd ros2_java_ws
+        colcon build --packages-skip test_msgs \
+          --cmake-args \
+          -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
+          -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+          -DANDROID_FUNCTION_LEVEL_LINKING=OFF \
+          -DANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL} \
+          -DANDROID_TOOLCHAIN_NAME=${ANDROID_TOOLCHAIN_NAME} \
+          -DANDROID_STL=c++_shared \
+          -DANDROID_ABI=${ANDROID_ABI} \
+          -DANDROID_NDK=${ANDROID_NDK} \
+          -DTHIRDPARTY=ON \
+          -DCOMPILE_EXAMPLES=OFF

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,15 +43,15 @@ jobs:
       run: |
         sudo pip3 install git+git://github.com/colcon/colcon-gradle.git
         sudo pip3 install git+git://github.com/colcon/colcon-ros-gradle.git
+    - name: Install Android NDK
+      run: |
+        curl -LO https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
+        unzip android-ndk-r21d-linux-x86_64.zip
     - name: Fetch VCS repo file
       run: |
         mkdir -p ros2_java_ws/src
         cd ros2_java_ws
         curl -sL https://raw.githubusercontent.com/ros2-java/ros2_java/jacob/android_instructions/ros2_java_android.repos | vcs import src
-    - name: Install Android NDK
-      run: |
-        curl -LO https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
-        unzip android-ndk-r21d-linux-x86_64.zip
     - name: Build ros2_java for Android
       run: |
         export PYTHON3_EXEC="$( which python3 )"
@@ -65,7 +65,7 @@ jobs:
         cd ros2_java_ws
         colcon build \
           --packages-ignore cyclonedds rcl_logging_log4cxx rosidl_generator_py \
-          --packages-up-to ros2_listener_android ros2_talker_android \
+          --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
           -DPYTHON_LIBRARY=${PYTHON3_LIBRARY} \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
         required-ros-distributions: dashing
     - uses: ros-tooling/action-ros-ci@8d58122
       with:
-        package-name: rosidl_generator_java rcljava_common rcljava rcljava_examples
+        package-name: rosidl_generator_java rcljava_common rcljava
         source-ros-binary-installation: dashing
         vcs-repo-file-url: https://raw.githubusercontent.com/ros2-java/ros2_java/dashing/ros2_java_desktop.repos
 
@@ -25,7 +25,7 @@ jobs:
     - name: Install Java
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y default-jdk
+        sudo apt-get install -y default-jdk gradle
     - name: Setup locale for ROS 2
       run: |
         sudo locale-gen en_US en_US.UTF-8
@@ -41,7 +41,6 @@ jobs:
         sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions python3-vcstool python3-lark-parser python3-dev
     - name: Install colcon extensions for Gradle
       run: |
-        sudo apt-get install -y gradle
         sudo pip3 install git+git://github.com/colcon/colcon-gradle.git
         sudo pip3 install git+git://github.com/colcon/colcon-ros-gradle.git
     - name: Fetch VCS repo file

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
         sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
     - name: Install colcon
       run: |
-        sudo apt-get update && sudo apt-get install -y python3-colcon3-common-extensions
+        sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions
     - name: Fetch VCS repo file
       run: |
         mkdir -p ros2_java_ws/src

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,7 +62,7 @@ jobs:
           --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
-          -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+          -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
           -DANDROID_FUNCTION_LEVEL_LINKING=OFF \
           -DANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL} \
           -DANDROID_TOOLCHAIN_NAME=${ANDROID_TOOLCHAIN_NAME} \
@@ -70,4 +70,5 @@ jobs:
           -DANDROID_ABI=${ANDROID_ABI} \
           -DANDROID_NDK=${ANDROID_NDK} \
           -DTHIRDPARTY=ON \
-          -DCOMPILE_EXAMPLES=OFF
+          -DCOMPILE_EXAMPLES=OFF \
+          -DCMAKE_FIND_ROOT_PATH="${PWD}/install"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,7 +58,7 @@ jobs:
 
         cd ros2_java_ws
         colcon build \
-          --packages-skip test_msgs \
+          --packages-skip test_msgs osrf_testing_tools_cpp \
           --packages-up-to rcljava \
           --cmake-args \
           -DBUILD_TESTING=OFF \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         mkdir -p ros2_java_ws/src
         cd ros2_java_ws
-        curl -skL https://raw.githubusercontent.com/ros2-java/ros2_java/jacob/android_instructions/ros2_android_desktop.repos | vcs import src
+        curl -skL https://raw.githubusercontent.com/ros2-java/ros2_java/jacob/android_instructions/ros2_java_android.repos | vcs import src
     - name: Build ros2_java for Android
       run: |
         export PYTHON3_EXEC="$( which python3 )"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
         required-ros-distributions: dashing
     - uses: ros-tooling/action-ros-ci@8d58122
       with:
-        package-name: rosidl_generator_java rcljava_common rcljava
+        package-name: rosidl_generator_java rcljava_common rcljava rcljava_examples
         source-ros-binary-installation: dashing
         vcs-repo-file-url: https://raw.githubusercontent.com/ros2-java/ros2_java/dashing/ros2_java_desktop.repos
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,6 +41,7 @@ jobs:
         sudo apt-get update && sudo apt-get install -y python3-colcon-common-extensions python3-vcstool python3-lark-parser python3-dev
     - name: Install colcon extensions for Gradle
       run: |
+        sudo apt-get install -y gradle
         sudo pip3 install git+git://github.com/colcon/colcon-gradle.git
         sudo pip3 install git+git://github.com/colcon/colcon-ros-gradle.git
     - name: Fetch VCS repo file

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -60,7 +60,7 @@ jobs:
 
         cd ros2_java_ws
         colcon build \
-          --packages-skip test_msgs cyclonedds rmw_cyclonedds \
+          --packages-skip test_msgs cyclonedds rmw_cyclonedds rcl_logging_log4cxx \
           --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \

--- a/README.md
+++ b/README.md
@@ -132,16 +132,22 @@ Although the `ros2_java_android.repos` file contains all the repositories for th
 1. Set Android build configuration:
 
         export PYTHON3_EXEC="$( which python3 )"
+        export PYTHON3_LIBRARY="$( ${PYTHON3_EXEC} -c 'import os.path; from distutils import sysconfig; print(os.path.realpath(os.path.join(sysconfig.get_config_var("LIBPL"), sysconfig.get_config_var("LDLIBRARY"))))' )"
+        export PYTHON3_INCLUDE_DIR="$( ${PYTHON3_EXEC} -c 'from distutils import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))' )"
         export ANDROID_ABI=armeabi-v7a
         export ANDROID_NATIVE_API_LEVEL=android-21
         export ANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-clang
 
 1. Build (skipping packages that we don't need or can't cross-compile):
 
-        colcon build --packages-skip test_msgs \
+        colcon build \
+          --packages-ignore cyclonedds rcl_logging_log4cxx rosidl_generator_py \
+          --packages-up-to rcljava \
           --cmake-args \
           -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
-          -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+          -DPYTHON_LIBRARY=${PYTHON3_LIBRARY} \
+          -DPYTHON_INCLUDE_DIR=${PYTHON3_INCLUDE_DIR} \
+          -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake \
           -DANDROID_FUNCTION_LEVEL_LINKING=OFF \
           -DANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL} \
           -DANDROID_TOOLCHAIN_NAME=${ANDROID_TOOLCHAIN_NAME} \
@@ -149,14 +155,7 @@ Although the `ros2_java_android.repos` file contains all the repositories for th
           -DANDROID_ABI=${ANDROID_ABI} \
           -DANDROID_NDK=${ANDROID_NDK} \
           -DTHIRDPARTY=ON \
-          -DCOMPILE_EXAMPLES=OFF
-
-          # TODO: These options may still need to be adapted
-          # -DCMAKE_FIND_ROOT_PATH="$AMENT_WORKSPACE/install_isolated;$ROS2_ANDROID_WORKSPACE/install_isolated" \
-          # -- \
-          # --parallel \
-          # --ament-gradle-args \
-          # -Pament.android_stl=gnustl_shared -Pament.android_abi=$ANDROID_ABI -Pament.android_ndk=$ANDROID_NDK --
-
+          -DCOMPILE_EXAMPLES=OFF \
+          -DCMAKE_FIND_ROOT_PATH="${PWD}/install"
 
 You can find more information about the Android examples at https://github.com/ros2-java/ros2_android_examples

--- a/README.md
+++ b/README.md
@@ -109,8 +109,6 @@ Make sure you have Gradle 3.2 (or later) installed.
 
 ### Download and Build ROS 2 Java for Android
 
-> TODO: This section needs updated instructions for ROS 2 Dashing and newer
-
 The Android setup is slightly more complex, you'll need the SDK and NDK installed, and an Android device where you can run the examples.
 
 Make sure to download at least the SDK for Android Lollipop (or greater), the examples require the API level 21 at least and NDK 14.
@@ -121,48 +119,44 @@ We'll also need to have the [Android SDK](https://developer.android.com/studio/#
 
 Although the `ros2_java_android.repos` file contains all the repositories for the Android bindings to compile, we'll have to disable certain packages (`python_cmake_module`, `rosidl_generator_py`, `test_msgs`) that are included the repositories and that we either don't need or can't cross-compile properly (e.g. the Python generator)
 
-```
-# define paths
-ROOT_DIR = ${HOME}
-AMENT_WORKSPACE=${ROOT_DIR}/ament_ws
-ROS2_ANDROID_WORKSPACE=${ROOT_DIR}/ros2_android_ws
+1. Download the [Android NDK](https://developer.android.com/ndk/downloads/index.html) and set the environment variable `ANDROID_NDK` to the path where it is extracted.
 
-# pull and build ament
-mkdir -p ${AMENT_WORKSPACE}/src
-cd ${AMENT_WORKSPACE}
-curl https://raw.githubusercontent.com/ros2-java/ament_java/master/ament_java.repos
-vcs import ${AMENT_WORKSPACE}/src < ament_java.repos
-src/ament/ament_tools/scripts/ament.py build --symlink-install --isolated
+1. Download the [Android SDK](https://developer.android.com/studio/#downloads) and set the environment variable `ANDROID_HOME` to the path where it is extracted.
 
-# android build configuration
-export PYTHON3_EXEC="$( which python3 )"
-export ANDROID_ABI=armeabi-v7a
-export ANDROID_NATIVE_API_LEVEL=android-21
-export ANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-clang
+1. Clone ROS 2 and ROS 2 Java source code:
 
-# pull and build ros2 for android
-mkdir -p ${ROS2_ANDROID_WORKSPACE}/src
-cd ${ROS2_ANDROID_WORKSPACE}
-curl https://raw.githubusercontent.com/ros2-java/ros2_java/dashing/ros2_java_android.repos
-vcs import ${ROS2_ANDROID_WORKSPACE}/src < ros2_java_android.repos
-source ${AMENT_WORKSPACE}/install_isolated/local_setup.sh
-ament build --isolated --skip-packages test_msgs \
-  --cmake-args \
-  -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
-  -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
-  -DANDROID_FUNCTION_LEVEL_LINKING=OFF \
-  -DANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL} \
-  -DANDROID_TOOLCHAIN_NAME=${ANDROID_TOOLCHAIN_NAME} \
-  -DANDROID_STL=gnustl_shared \
-  -DANDROID_ABI=${ANDROID_ABI} \
-  -DANDROID_NDK=${ANDROID_NDK} \
-  -DTHIRDPARTY=ON \
-  -DCOMPILE_EXAMPLES=OFF \
-  -DCMAKE_FIND_ROOT_PATH="$AMENT_WORKSPACE/install_isolated;$ROS2_ANDROID_WORKSPACE/install_isolated" \
-  -- \
-  --parallel \
-  --ament-gradle-args \
-  -Pament.android_stl=gnustl_shared -Pament.android_abi=$ANDROID_ABI -Pament.android_ndk=$ANDROID_NDK --
-```
+        mkdir -p $HOME/ros2_android_ws/src
+        cd $HOME/ros2_android_ws
+        curl https://raw.githubusercontent.com/ros2-java/ros2_java/dashing/ros2_java_android.repos | vcs import src
+
+1. Set Android build configuration:
+
+        export PYTHON3_EXEC="$( which python3 )"
+        export ANDROID_ABI=armeabi-v7a
+        export ANDROID_NATIVE_API_LEVEL=android-21
+        export ANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-clang
+
+1. Build (skipping packages that we don't need or can't cross-compile):
+
+        colcon build --packages-skip test_msgs \
+          --cmake-args \
+          -DPYTHON_EXECUTABLE=${PYTHON3_EXEC} \
+          -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+          -DANDROID_FUNCTION_LEVEL_LINKING=OFF \
+          -DANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL} \
+          -DANDROID_TOOLCHAIN_NAME=${ANDROID_TOOLCHAIN_NAME} \
+          -DANDROID_STL=c++_shared \
+          -DANDROID_ABI=${ANDROID_ABI} \
+          -DANDROID_NDK=${ANDROID_NDK} \
+          -DTHIRDPARTY=ON \
+          -DCOMPILE_EXAMPLES=OFF
+
+          # TODO: These options may still need to be adapted
+          # -DCMAKE_FIND_ROOT_PATH="$AMENT_WORKSPACE/install_isolated;$ROS2_ANDROID_WORKSPACE/install_isolated" \
+          # -- \
+          # --parallel \
+          # --ament-gradle-args \
+          # -Pament.android_stl=gnustl_shared -Pament.android_abi=$ANDROID_ABI -Pament.android_ndk=$ANDROID_NDK --
+
 
 You can find more information about the Android examples at https://github.com/ros2-java/ros2_android_examples

--- a/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
@@ -47,8 +47,6 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.ref.WeakReference;
 
-import java.lang.reflect.Method;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
@@ -52,7 +52,7 @@ public class ClientTest {
       // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
       Class c = Class.forName("org.apache.log4j.BasicConfigurator");
       Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
-      Object o = m.invoke(null, (Object<?>[]) null);
+      Object o = m.invoke(null, (Object[]) null);
     }
     catch (Exception e)
     {

--- a/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
@@ -26,6 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
 import java.time.Duration;
 
 import java.util.Arrays;

--- a/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/client/ClientTest.java
@@ -46,7 +46,18 @@ public class ClientTest {
   @BeforeClass
   public static void setupOnce() throws Exception {
     RCLJava.rclJavaInit();
-    org.apache.log4j.BasicConfigurator.configure();
+    try
+    {
+      // Configure log4j. Doing this dynamically so that Android does not complain about missing
+      // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
+      Class c = Class.forName("org.apache.log4j.BasicConfigurator");
+      Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
+      Object o = m.invoke(null, (Object<?>[]) null);
+    }
+    catch (Exception e)
+    {
+      e.printStackTrace();
+    }
   }
 
   public class TestClientConsumer implements TriConsumer<RMWRequestId,

--- a/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
@@ -92,7 +92,7 @@ public class NodeTest {
       // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
       Class c = Class.forName("org.apache.log4j.BasicConfigurator");
       Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
-      Object o = m.invoke(null, (Object<?>[]) null);
+      Object o = m.invoke(null, (Object[]) null);
     }
     catch (Exception e)
     {

--- a/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
@@ -26,6 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
 
 import java.util.Arrays;
 import java.util.List;

--- a/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
@@ -86,7 +86,18 @@ public class NodeTest {
   @BeforeClass
   public static void setupOnce() throws Exception {
     RCLJava.rclJavaInit();
-    org.apache.log4j.BasicConfigurator.configure();
+    try
+    {
+      // Configure log4j. Doing this dynamically so that Android does not complain about missing
+      // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
+      Class c = Class.forName("org.apache.log4j.BasicConfigurator");
+      Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
+      Object o = m.invoke(null, (Object<?>[]) null);
+    }
+    catch (Exception e)
+    {
+      e.printStackTrace();
+    }
   }
 
   public class TestConsumer<T> implements Consumer<T> {

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
@@ -26,6 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
@@ -69,7 +69,18 @@ public class AsyncParametersClientTest {
   @BeforeClass
   public static void setupOnce() throws Exception {
     RCLJava.rclJavaInit();
-    org.apache.log4j.BasicConfigurator.configure();
+    try
+    {
+      // Configure log4j. Doing this dynamically so that Android does not complain about missing
+      // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
+      Class c = Class.forName("org.apache.log4j.BasicConfigurator");
+      Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
+      Object o = m.invoke(null, (Object<?>[]) null);
+    }
+    catch (Exception e)
+    {
+      e.printStackTrace();
+    }
   }
 
   @Before

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
@@ -75,7 +75,7 @@ public class AsyncParametersClientTest {
       // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
       Class c = Class.forName("org.apache.log4j.BasicConfigurator");
       Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
-      Object o = m.invoke(null, (Object<?>[]) null);
+      Object o = m.invoke(null, (Object[]) null);
     }
     catch (Exception e)
     {

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
@@ -26,6 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
@@ -58,7 +58,7 @@ public class SyncParametersClientTest {
       // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
       Class c = Class.forName("org.apache.log4j.BasicConfigurator");
       Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
-      Object o = m.invoke(null, (Object<?>[]) null);
+      Object o = m.invoke(null, (Object[]) null);
     }
     catch (Exception e)
     {

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
@@ -52,7 +52,18 @@ public class SyncParametersClientTest {
   @BeforeClass
   public static void setupOnce() throws Exception {
     RCLJava.rclJavaInit();
-    org.apache.log4j.BasicConfigurator.configure();
+    try
+    {
+      // Configure log4j. Doing this dynamically so that Android does not complain about missing
+      // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
+      Class c = Class.forName("org.apache.log4j.BasicConfigurator");
+      Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
+      Object o = m.invoke(null, (Object<?>[]) null);
+    }
+    catch (Exception e)
+    {
+      e.printStackTrace();
+    }
   }
 
   @Before

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -85,8 +85,8 @@ repositories:
     version: dashing
   ros2/rmw:
     type: git
-    url: https://github.com/ros2-java/rmw.git
-    version: dashing-android
+    url: https://github.com/ros2/rmw.git
+    version: dashing
   ros2/rmw_connext:
     type: git
     url: https://github.com/ros2/rmw_connext.git

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -1,31 +1,135 @@
 repositories:
+  ament/ament_cmake:
+    type: git
+    url: https://github.com/ament/ament_cmake.git
+    version: dashing
+  ament/ament_index:
+    type: git
+    url: https://github.com/ament/ament_index.git
+    version: dashing
+  ament/ament_lint:
+    type: git
+    url: https://github.com/ament/ament_lint.git
+    version: dashing
+  ament/ament_package:
+    type: git
+    url: https://github.com/ament/ament_package.git
+    version: dashing
+  ament/googletest:
+    type: git
+    url: https://github.com/ament/googletest.git
+    version: dashing
+  ament/uncrustify_vendor:
+    type: git
+    url: https://github.com/ament/uncrustify_vendor.git
+    version: dashing
+  ament/ament_java:
+    type: git
+    url: https://github.com/ros2-java/ament_java.git
+    version: master
+  eclipse-cyclonedds/cyclonedds:
+    type: git
+    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+    version: releases/0.5.x
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
     version: v1.0.11
-  eProsima/Fast-RTPS:
+  eProsima/Fast-DDS:
     type: git
-    url: https://github.com/eProsima/Fast-RTPS.git
+    url: https://github.com/eProsima/Fast-DDS.git
     version: v1.8.2
+  osrf/osrf_pycommon:
+    type: git
+    url: https://github.com/osrf/osrf_pycommon.git
+    version: dashing
+  osrf/osrf_testing_tools_cpp:
+    type: git
+    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+    version: dashing
+  ros-perception/laser_geometry:
+    type: git
+    url: https://github.com/ros-perception/laser_geometry.git
+    version: dashing
+  ros-planning/navigation_msgs:
+    type: git
+    url: https://github.com/ros-planning/navigation_msgs.git
+    version: ros2
+  ros/class_loader:
+    type: git
+    url: https://github.com/ros/class_loader.git
+    version: dashing
+  ros/pluginlib:
+    type: git
+    url: https://github.com/ros/pluginlib.git
+    version: dashing
+  ros/kdl_parser:
+    type: git
+    url: https://github.com/ros/kdl_parser.git
+    version: dashing
+  ros/resource_retriever:
+    type: git
+    url: https://github.com/ros/resource_retriever.git
+    version: dashing
+  ros/ros_environment:
+    type: git
+    url: https://github.com/ros/ros_environment.git
+    version: dashing
+  ros/urdfdom_headers:
+    type: git
+    url: https://github.com/ros/urdfdom_headers.git
+    version: dashing
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: dashing
-  ros2/rcutils:
-    type: git
-    url: https://github.com/ros2/rcutils.git
     version: dashing
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
     version: dashing
+  ros2/console_bridge_vendor:
+    type: git
+    url: https://github.com/ros2/console_bridge_vendor.git
+    version: dashing
+  ros2/demos:
+    type: git
+    url: https://github.com/ros2/demos.git
+    version: dashing
+  ros2/eigen3_cmake_module:
+    type: git
+    url: https://github.com/ros2/eigen3_cmake_module.git
+    version: master
+  ros2/examples:
+    type: git
+    url: https://github.com/ros2/examples.git
+    version: dashing
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
     version: dashing
+  ros2/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: dashing
+  ros2/launch:
+    type: git
+    url: https://github.com/ros2/launch.git
+    version: dashing
+  ros2/launch_ros:
+    type: git
+    url: https://github.com/ros2/launch_ros.git
+    version: dashing
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
+    version: dashing
+  ros2/message_filters:
+    type: git
+    url: https://github.com/ros2/message_filters.git
+    version: dashing
+  ros2/orocos_kinematics_dynamics:
+    type: git
+    url: https://github.com/ros2/orocos_kinematics_dynamics.git
     version: dashing
   ros2/poco_vendor:
     type: git
@@ -39,10 +143,42 @@ repositories:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
     version: dashing
+  ros2/rcl_logging:
+    type: git
+    url: https://github.com/ros2/rcl_logging.git
+    version: dashing
+  ros2/rclcpp:
+    type: git
+    url: https://github.com/ros2/rclcpp.git
+    version: dashing
+  ros2/rclpy:
+    type: git
+    url: https://github.com/ros2/rclpy.git
+    version: dashing
+  ros2/rcpputils:
+    type: git
+    url: https://github.com/ros2/rcpputils.git
+    version: dashing
+  ros2/rcutils:
+    type: git
+    url: https://github.com/ros2/rcutils.git
+    version: dashing
+  ros2/realtime_support:
+    type: git
+    url: https://github.com/ros2/realtime_support.git
+    version: dashing
   ros2/rmw:
     type: git
     url: https://github.com/ros2/rmw.git
     version: dashing
+  ros2/rmw_connext:
+    type: git
+    url: https://github.com/ros2/rmw_connext.git
+    version: dashing
+  ros2/rmw_cyclonedds:
+    type: git
+    url: https://github.com/ros2/rmw_cyclonedds.git
+    version: dashing-eloquent
   ros2/rmw_fastrtps:
     type: git
     url: https://github.com/ros2/rmw_fastrtps.git
@@ -50,6 +186,30 @@ repositories:
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
+    version: dashing
+  ros2/rmw_opensplice:
+    type: git
+    url: https://github.com/ros2/rmw_opensplice.git
+    version: dashing
+  ros2/robot_state_publisher:
+    type: git
+    url: https://github.com/ros2/robot_state_publisher.git
+    version: dashing
+  ros2/ros_testing:
+    type: git
+    url: https://github.com/ros2/ros_testing.git
+    version: dashing
+  ros2/ros1_bridge:
+    type: git
+    url: https://github.com/ros2/ros1_bridge.git
+    version: dashing
+  ros2/ros2cli:
+    type: git
+    url: https://github.com/ros2/ros2cli.git
+    version: dashing
+  ros2/rosbag2:
+    type: git
+    url: https://github.com/ros2/rosbag2.git
     version: dashing
   ros2/rosidl:
     type: git
@@ -63,13 +223,73 @@ repositories:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
     version: dashing
+  ros2/rosidl_python:
+    type: git
+    url: https://github.com/ros2/rosidl_python.git
+    version: dashing
   ros2/rosidl_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_typesupport.git
     version: dashing
-  ros2/osrf_testing_tools_cpp:
+  ros2/rosidl_typesupport_connext:
     type: git
-    url: https://github.com/osrf/osrf_testing_tools_cpp
+    url: https://github.com/ros2/rosidl_typesupport_connext.git
+    version: dashing
+  ros2/rosidl_typesupport_fastrtps:
+    type: git
+    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+    version: dashing
+  ros2/rosidl_typesupport_opensplice:
+    type: git
+    url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+    version: dashing
+  ros2/rviz:
+    type: git
+    url: https://github.com/ros2/rviz.git
+    version: dashing
+  ros2/sros2:
+    type: git
+    url: https://github.com/ros2/sros2.git
+    version: dashing
+  ros2/system_tests:
+    type: git
+    url: https://github.com/ros2/system_tests.git
+    version: dashing
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: dashing
+  ros2/tinydir_vendor:
+    type: git
+    url: https://github.com/ros2/tinydir_vendor.git
+    version: dashing
+  ros2/tinyxml2_vendor:
+    type: git
+    url: https://github.com/ros2/tinyxml2_vendor.git
+    version: dashing
+  ros2/tinyxml_vendor:
+    type: git
+    url: https://github.com/ros2/tinyxml_vendor.git
+    version: dashing
+  ros2/tlsf:
+    type: git
+    url: https://github.com/ros2/tlsf.git
+    version: dashing
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: dashing
+  ros2/urdf:
+    type: git
+    url: https://github.com/ros2/urdf.git
+    version: dashing
+  ros2/urdfdom:
+    type: git
+    url: https://github.com/ros2/urdfdom.git
+    version: dashing
+  ros2/yaml_cpp_vendor:
+    type: git
+    url: https://github.com/ros2/yaml_cpp_vendor.git
     version: dashing
   ros2_java/ros2_java:
     type: git

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -157,7 +157,7 @@ repositories:
     version: jacob/android_instructions
   ros2_java/ros2_android:
     type: git
-    url: https://github.com/esteve/ros2_android.git
+    url: https://github.com/ros2-java/ros2_android.git
     version: master
   ros2_java/ros2_android_examples:
     type: git

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -169,8 +169,8 @@ repositories:
     version: dashing
   ros2/rmw:
     type: git
-    url: https://github.com/ros2/rmw.git
-    version: dashing
+    url: https://github.com/ros2-java/rmw.git
+    version: dashing-android
   ros2/rmw_connext:
     type: git
     url: https://github.com/ros2/rmw_connext.git

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -154,7 +154,7 @@ repositories:
   ros2_java/ros2_java:
     type: git
     url: https://github.com/ros2-java/ros2_java
-    version: jacob/android_instructions
+    version: dashing
   ros2_java/ros2_android:
     type: git
     url: https://github.com/ros2-java/ros2_android.git

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -15,6 +15,10 @@ repositories:
     type: git
     url: https://github.com/ament/ament_package.git
     version: dashing
+  ament/googletest:
+    type: git
+    url: https://github.com/ament/googletest.git
+    version: dashing
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -294,7 +294,7 @@ repositories:
   ros2_java/ros2_java:
     type: git
     url: https://github.com/ros2-java/ros2_java
-    version: dashing
+    version: jacob/android_instructions
   ros2_java/ros2_android:
     type: git
     url: https://github.com/esteve/ros2_android.git

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -45,8 +45,8 @@ repositories:
     version: dashing
   osrf/osrf_testing_tools_cpp:
     type: git
-    url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: dashing
+    url: https://github.com/ros2-java/osrf_testing_tools_cpp.git
+    version: dashing-android
   ros-perception/laser_geometry:
     type: git
     url: https://github.com/ros-perception/laser_geometry.git

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -15,10 +15,6 @@ repositories:
     type: git
     url: https://github.com/ament/ament_package.git
     version: dashing
-  ament/googletest:
-    type: git
-    url: https://github.com/ament/googletest.git
-    version: dashing
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
@@ -27,10 +23,6 @@ repositories:
     type: git
     url: https://github.com/ros2-java/ament_java.git
     version: master
-  eclipse-cyclonedds/cyclonedds:
-    type: git
-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: releases/0.5.x
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
@@ -47,38 +39,6 @@ repositories:
     type: git
     url: https://github.com/ros2-java/osrf_testing_tools_cpp.git
     version: dashing-android
-  ros-perception/laser_geometry:
-    type: git
-    url: https://github.com/ros-perception/laser_geometry.git
-    version: dashing
-  ros-planning/navigation_msgs:
-    type: git
-    url: https://github.com/ros-planning/navigation_msgs.git
-    version: ros2
-  ros/class_loader:
-    type: git
-    url: https://github.com/ros/class_loader.git
-    version: dashing
-  ros/pluginlib:
-    type: git
-    url: https://github.com/ros/pluginlib.git
-    version: dashing
-  ros/kdl_parser:
-    type: git
-    url: https://github.com/ros/kdl_parser.git
-    version: dashing
-  ros/resource_retriever:
-    type: git
-    url: https://github.com/ros/resource_retriever.git
-    version: dashing
-  ros/ros_environment:
-    type: git
-    url: https://github.com/ros/ros_environment.git
-    version: dashing
-  ros/urdfdom_headers:
-    type: git
-    url: https://github.com/ros/urdfdom_headers.git
-    version: dashing
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
@@ -87,49 +47,13 @@ repositories:
     type: git
     url: https://github.com/ros2/common_interfaces.git
     version: dashing
-  ros2/console_bridge_vendor:
-    type: git
-    url: https://github.com/ros2/console_bridge_vendor.git
-    version: dashing
-  ros2/demos:
-    type: git
-    url: https://github.com/ros2/demos.git
-    version: dashing
-  ros2/eigen3_cmake_module:
-    type: git
-    url: https://github.com/ros2/eigen3_cmake_module.git
-    version: master
-  ros2/examples:
-    type: git
-    url: https://github.com/ros2/examples.git
-    version: dashing
   ros2/example_interfaces:
     type: git
     url: https://github.com/ros2/example_interfaces.git
     version: dashing
-  ros2/geometry2:
-    type: git
-    url: https://github.com/ros2/geometry2.git
-    version: dashing
   ros2/launch:
     type: git
     url: https://github.com/ros2/launch.git
-    version: dashing
-  ros2/launch_ros:
-    type: git
-    url: https://github.com/ros2/launch_ros.git
-    version: dashing
-  ros2/libyaml_vendor:
-    type: git
-    url: https://github.com/ros2/libyaml_vendor.git
-    version: dashing
-  ros2/message_filters:
-    type: git
-    url: https://github.com/ros2/message_filters.git
-    version: dashing
-  ros2/orocos_kinematics_dynamics:
-    type: git
-    url: https://github.com/ros2/orocos_kinematics_dynamics.git
     version: dashing
   ros2/poco_vendor:
     type: git
@@ -147,14 +71,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rcl_logging.git
     version: dashing
-  ros2/rclcpp:
-    type: git
-    url: https://github.com/ros2/rclcpp.git
-    version: dashing
-  ros2/rclpy:
-    type: git
-    url: https://github.com/ros2/rclpy.git
-    version: dashing
   ros2/rcpputils:
     type: git
     url: https://github.com/ros2/rcpputils.git
@@ -162,10 +78,6 @@ repositories:
   ros2/rcutils:
     type: git
     url: https://github.com/ros2/rcutils.git
-    version: dashing
-  ros2/realtime_support:
-    type: git
-    url: https://github.com/ros2/realtime_support.git
     version: dashing
   ros2/rmw:
     type: git
@@ -190,26 +102,6 @@ repositories:
   ros2/rmw_opensplice:
     type: git
     url: https://github.com/ros2/rmw_opensplice.git
-    version: dashing
-  ros2/robot_state_publisher:
-    type: git
-    url: https://github.com/ros2/robot_state_publisher.git
-    version: dashing
-  ros2/ros_testing:
-    type: git
-    url: https://github.com/ros2/ros_testing.git
-    version: dashing
-  ros2/ros1_bridge:
-    type: git
-    url: https://github.com/ros2/ros1_bridge.git
-    version: dashing
-  ros2/ros2cli:
-    type: git
-    url: https://github.com/ros2/ros2cli.git
-    version: dashing
-  ros2/rosbag2:
-    type: git
-    url: https://github.com/ros2/rosbag2.git
     version: dashing
   ros2/rosidl:
     type: git
@@ -243,18 +135,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_opensplice.git
     version: dashing
-  ros2/rviz:
-    type: git
-    url: https://github.com/ros2/rviz.git
-    version: dashing
-  ros2/sros2:
-    type: git
-    url: https://github.com/ros2/sros2.git
-    version: dashing
-  ros2/system_tests:
-    type: git
-    url: https://github.com/ros2/system_tests.git
-    version: dashing
   ros2/test_interface_files:
     type: git
     url: https://github.com/ros2/test_interface_files.git
@@ -263,33 +143,9 @@ repositories:
     type: git
     url: https://github.com/ros2/tinydir_vendor.git
     version: dashing
-  ros2/tinyxml2_vendor:
-    type: git
-    url: https://github.com/ros2/tinyxml2_vendor.git
-    version: dashing
-  ros2/tinyxml_vendor:
-    type: git
-    url: https://github.com/ros2/tinyxml_vendor.git
-    version: dashing
-  ros2/tlsf:
-    type: git
-    url: https://github.com/ros2/tlsf.git
-    version: dashing
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: dashing
-  ros2/urdf:
-    type: git
-    url: https://github.com/ros2/urdf.git
-    version: dashing
-  ros2/urdfdom:
-    type: git
-    url: https://github.com/ros2/urdfdom.git
-    version: dashing
-  ros2/yaml_cpp_vendor:
-    type: git
-    url: https://github.com/ros2/yaml_cpp_vendor.git
     version: dashing
   ros2_java/ros2_java:
     type: git

--- a/rosidl_generator_java/resource/msg.cpp.em
+++ b/rosidl_generator_java/resource/msg.cpp.em
@@ -202,7 +202,7 @@ JNIEXPORT jlong JNICALL Java_@(underscore_separated_jni_type_name)_getDestructor
   JNIEnv * env = nullptr;
   // TODO(esteve): check return status
   assert(g_vm != nullptr);
-  g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_8);
+  g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
   assert(env != nullptr);
 
   if (ros_message == nullptr) {
@@ -331,7 +331,7 @@ jobject @(underscore_separated_type_name)__convert_to_java(@(msg_normalized_type
   JNIEnv * env = nullptr;
   // TODO(esteve): check return status
   assert(g_vm != nullptr);
-  g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_8);
+  g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
   assert(env != nullptr);
 
   if (_jmessage_obj == nullptr) {
@@ -435,7 +435,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM * vm, void *)
   }
 
   JNIEnv * env;
-  if (g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_8) != JNI_OK) {
+  if (g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
     return JNI_ERR;
   } else {
 @[for normalized_type, jni_type in cache.items()]@
@@ -484,7 +484,7 @@ if value_method:
 @[  end if]@
 @[end for]@
   }
-  return JNI_VERSION_1_8;
+  return JNI_VERSION_1_6;
 }
 
 JNIEXPORT void JNICALL JNI_OnUnload(JavaVM * vm, void *)
@@ -493,7 +493,7 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM * vm, void *)
   assert(g_vm == vm);
 
   JNIEnv * env;
-  if (g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_8) == JNI_OK) {
+  if (g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) == JNI_OK) {
 @[for normalized_type, jni_type in cache.items()]@
     if (_j@(normalized_type)_class_global != nullptr) {
       env->DeleteGlobalRef(_j@(normalized_type)_class_global);

--- a/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
+++ b/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 import java.util.Arrays;
 import java.util.List;
@@ -30,7 +31,18 @@ import org.junit.rules.ExpectedException;
 public class InterfacesTest {
   @BeforeClass
   public static void setupOnce() {
-    org.apache.log4j.BasicConfigurator.configure();
+    try
+    {
+      // Configure log4j. Doing this dynamically so that Android does not complain about missing
+      // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
+      Class c = Class.forName("org.apache.log4j.BasicConfigurator");
+      Method m = c.getDeclaredMethod("configure", null);
+      Object o = m.invoke(null, null);
+    }
+    catch (Exception e)
+    {
+      e.printStackTrace();
+    }
   }
 
   @Rule public ExpectedException thrown = ExpectedException.none();

--- a/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
+++ b/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
@@ -36,8 +36,8 @@ public class InterfacesTest {
       // Configure log4j. Doing this dynamically so that Android does not complain about missing
       // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
       Class c = Class.forName("org.apache.log4j.BasicConfigurator");
-      Method m = c.getDeclaredMethod("configure", null);
-      Object o = m.invoke(null, null);
+      Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
+      Object o = m.invoke(null, (Object<?>[]) null);
     }
     catch (Exception e)
     {

--- a/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
+++ b/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
@@ -37,7 +37,7 @@ public class InterfacesTest {
       // the log4j JARs, SLF4J uses Android's native logging mechanism instead.
       Class c = Class.forName("org.apache.log4j.BasicConfigurator");
       Method m = c.getDeclaredMethod("configure", (Class<?>[]) null);
-      Object o = m.invoke(null, (Object<?>[]) null);
+      Object o = m.invoke(null, (Object[]) null);
     }
     catch (Exception e)
     {


### PR DESCRIPTION
This is a work in progress; still troubleshooting build issues.

Changes made so far:

- Switch to `colcon` instead of `ament build`
- Change `ANDROID_STL` value to `c++_shared` (as `gnustl_shared` is no longer supported)
- Updated the repos file to reflect what is in Dashing, minus the Qt packages (c9498cd)

I've left commented out additional build options that I'm not sure how to port to the new colcon command.

Following the steps in in this PR, I get the following build error with `ament_cmake_libraries`:

```
--- stderr: ament_cmake_libraries
CMake Error at CMakeLists.txt:5 (find_package):
  By not providing "Findament_cmake_core.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "ament_cmake_core", but CMake did not find one.

  Could not find a package configuration file provided by "ament_cmake_core"
  with any of the following names:

    ament_cmake_coreConfig.cmake
    ament_cmake_core-config.cmake

  Add the installation prefix of "ament_cmake_core" to CMAKE_PREFIX_PATH or
  set "ament_cmake_core_DIR" to a directory containing one of the above
  files.  If "ament_cmake_core" provides a separate development package or
  SDK, be sure it has been installed.


---
```

I'm not sure what's going wrong.