### PR TITLE
(RclJava) fix BaseExecutor.spinSome logic - run the executable even i…

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/executors/BaseExecutor.java
@@ -332,12 +332,12 @@ public class BaseExecutor {
     AnyExecutable anyExecutable = getNextExecutable();
     if (anyExecutable == null) {
       waitForWork(0);
-      do {
-        anyExecutable = getNextExecutable();
-        if (anyExecutable != null) {
-          executeAnyExecutable(anyExecutable);
-        }
-      } while (anyExecutable != null);
+      anyExecutable = getNextExecutable();
+    }
+
+    while (anyExecutable != null) {
+      executeAnyExecutable(anyExecutable);
+      anyExecutable = getNextExecutable();
     }
   }
 


### PR DESCRIPTION
Currently, executable did not run if getNextExecutable() is not null.