### PR TITLE
Add getClock method to Node interface (#43)

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/Node.java
@@ -33,6 +33,7 @@ import org.ros2.rcljava.publisher.Publisher;
 import org.ros2.rcljava.service.RMWRequestId;
 import org.ros2.rcljava.service.Service;
 import org.ros2.rcljava.subscription.Subscription;
+import org.ros2.rcljava.time.Clock;
 import org.ros2.rcljava.timer.Timer;
 import org.ros2.rcljava.timer.WallTimer;
 
@@ -41,6 +42,11 @@ import org.ros2.rcljava.timer.WallTimer;
  * A Node must be created via @{link RCLJava#createNode(String)}
  */
 public interface Node extends Disposable {
+  /**
+   * @return The nodes @{link Clock}.
+   */
+  Clock getClock();
+
   /**
    * return All the @{link Client}s that have been created by this instance.
    */

--- a/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
@@ -179,6 +179,13 @@ public class NodeImpl implements Node {
   /**
    * {@inheritDoc}
    */
+  public final Clock getClock() {
+    return this.clock;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public final <T extends MessageDefinition> Publisher<T> createPublisher(
       final Class<T> messageType, final String topic, final QoSProfile qosProfile) {
     long qosProfileHandle = RCLJava.convertQoSProfileToHandle(qosProfile);


### PR DESCRIPTION
Useful for getting the current time from the Clock instance.

This is a prerequisite for the action server implementation.