### PR TITLE
Compile generated action-related services

### DIFF
--- a/rosidl_generator_java/cmake/rosidl_generator_java_generate_interfaces.cmake
+++ b/rosidl_generator_java/cmake/rosidl_generator_java_generate_interfaces.cmake
@@ -81,11 +81,23 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
       "${_output_path}/${_parent_folder}/${_idl_name}_Goal.java"
       "${_output_path}/${_parent_folder}/${_idl_name}_Result.java"
       "${_output_path}/${_parent_folder}/${_idl_name}_Feedback.java"
+      "${_output_path}/${_parent_folder}/${_idl_name}_SendGoal.java"
+      "${_output_path}/${_parent_folder}/${_idl_name}_SendGoal_Request.java"
+      "${_output_path}/${_parent_folder}/${_idl_name}_SendGoal_Response.java"
+      "${_output_path}/${_parent_folder}/${_idl_name}_GetResult.java"
+      "${_output_path}/${_parent_folder}/${_idl_name}_GetResult_Request.java"
+      "${_output_path}/${_parent_folder}/${_idl_name}_GetResult_Response.java"
     )
     foreach(_typesupport_impl ${_typesupport_impls})
       list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_Goal.ep.${_typesupport_impl}.cpp")
       list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_Result.ep.${_typesupport_impl}.cpp")
       list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_Feedback.ep.${_typesupport_impl}.cpp")
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_SendGoal.ep.${_typesupport_impl}.cpp")
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_SendGoal_Request.ep.${_typesupport_impl}.cpp")
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_SendGoal_Response.ep.${_typesupport_impl}.cpp")
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_GetResult.ep.${_typesupport_impl}.cpp")
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_GetResult_Request.ep.${_typesupport_impl}.cpp")
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/${_idl_name}_GetResult_Response.ep.${_typesupport_impl}.cpp")
     endforeach()
   endif()
 

--- a/rosidl_generator_java/resource/action.cpp.em
+++ b/rosidl_generator_java/resource/action.cpp.em
@@ -58,25 +58,8 @@ expand_template(
     data,
     output_file)
 
-# Generate SendGoal message type
-data.update({'msg': action.send_goal_service.request_message})
-output_file = os.path.join(output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(send_goal_type_name, typesupport_impl))
-expand_template(
-    'msg.cpp.em',
-    data,
-    output_file)
-
-# Generate GetResult message type
-data.update({'msg': action.get_result_service.request_message})
-output_file = os.path.join(output_dir, *namespaces[1:], '{0}.ep.{1}.cpp'.format(send_goal_type_name, typesupport_impl))
-expand_template(
-    'msg.cpp.em',
-    data,
-    output_file)
-
 data = {
     'package_name': package_name,
-    'interface_path': interface_path,
     'output_dir': output_dir,
     'template_basepath': template_basepath,
     'typesupport_impl': typesupport_impl,

--- a/rosidl_generator_java/resource/action.java.em
+++ b/rosidl_generator_java/resource/action.java.em
@@ -13,6 +13,8 @@ type_name = action.namespaced_type.name
 goal_type_name = action.goal.structure.namespaced_type.name
 result_type_name = action.result.structure.namespaced_type.name
 feedback_type_name = action.feedback.structure.namespaced_type.name
+send_goal_type_name = action.send_goal_service.namespaced_type.name
+get_result_type_name = action.get_result_service.namespaced_type.name
 
 data = {
     'package_name': package_name,
@@ -40,6 +42,22 @@ data.update({'message': action.feedback})
 output_file = os.path.join(output_dir, *namespaces[1:], feedback_type_name + '.java')
 expand_template(
     'msg.java.em',
+    data,
+    output_file,
+    template_basepath=template_basepath)
+
+data.update({'service': action.send_goal_service})
+output_file = os.path.join(output_dir, *namespaces[1:], send_goal_type_name + '.java')
+expand_template(
+    'srv.java.em',
+    data,
+    output_file,
+    template_basepath=template_basepath)
+
+data.update({'service': action.get_result_service})
+output_file = os.path.join(output_dir, *namespaces[1:], get_result_type_name + '.java')
+expand_template(
+    'srv.java.em',
     data,
     output_file,
     template_basepath=template_basepath)

--- a/rosidl_generator_java/resource/msg.cpp.em
+++ b/rosidl_generator_java/resource/msg.cpp.em
@@ -62,6 +62,7 @@ for member in message.structure.members:
         namespaced_types.add(get_jni_type(type_))
         include_prefix = idl_structure_type_to_c_include_prefix(type_)
         # TODO(jacobperron): Remove this logic after https://github.com/ros2/rosidl/pull/432 (Foxy)
+        #                    and https://github.com/ros2/rosidl/pull/538
         # Strip off any service or action suffix
         # There are several types that actions and services are composed of, but they are included
         # a common header that is based on the action or service name
@@ -76,10 +77,15 @@ for member in message.structure.members:
             include_prefix = include_prefix[:-8]
         elif include_prefix.endswith('__feedback'):
             include_prefix = include_prefix[:-10]
+        elif include_prefix.endswith('__send_goal'):
+            include_prefix = include_prefix[:-11]
+        elif include_prefix.endswith('__get_result'):
+            include_prefix = include_prefix[:-12]
         member_includes.add(include_prefix + '.h')
 }@
 @{
 # TODO(jacobperron): Remove this logic after https://github.com/ros2/rosidl/pull/432 (Foxy)
+#                    and https://github.com/ros2/rosidl/pull/538
 message_c_include_prefix = idl_structure_type_to_c_include_prefix(message.structure.namespaced_type)
 # Strip off any service or action suffix
 if message_c_include_prefix.endswith('__request'):
@@ -92,6 +98,10 @@ elif message_c_include_prefix.endswith('__result'):
     message_c_include_prefix = message_c_include_prefix[:-8]
 elif message_c_include_prefix.endswith('__feedback'):
     message_c_include_prefix = message_c_include_prefix[:-10]
+elif message_c_include_prefix.endswith('__send_goal'):
+    message_c_include_prefix = message_c_include_prefix[:-11]
+elif message_c_include_prefix.endswith('__get_result'):
+    message_c_include_prefix = message_c_include_prefix[:-12]
 }@
 
 #include <jni.h>

--- a/rosidl_generator_java/resource/srv.cpp.em
+++ b/rosidl_generator_java/resource/srv.cpp.em
@@ -40,7 +40,20 @@ expand_template(
 
 #include "rosidl_generator_c/service_type_support_struct.h"
 
-#include "@(idl_structure_type_to_c_include_prefix(service.namespaced_type)).h"
+@{
+include_prefix = idl_structure_type_to_c_include_prefix(service.namespaced_type)
+# TODO(jacobperron): Remove this logic after https://github.com/ros2/rosidl/pull/538
+# Strip off any service suffix
+# There are a couple service types that actions are composed of, but they are included
+# a common header that is based on the action name
+# ie. there are not separate headers for each type
+if include_prefix.endswith('__send_goal'):
+    include_prefix = include_prefix[:-11]
+elif include_prefix.endswith('__get_result'):
+    include_prefix = include_prefix[:-12]
+}@
+
+#include "@(include_prefix).h"
 
 // Ensure that a jlong is big enough to store raw pointers
 static_assert(sizeof(jlong) >= sizeof(std::intptr_t), "jlong must be able to store pointers");


### PR DESCRIPTION
Though service generation was fixed in #76, the new files were not added to the CMakeLists.txt for compilation. This PR contains the following:

* Clean up some redundant code generation (7da1faf)
* Fix compilation errors (50d2789)
* Generate Java equivalent code for service definitions (e1a70cf)
* Add generated code to the CMakeLists.txt for compilation (86b4240)