### PR TITLE
Add interfaces for action goal, result, and feedback

### DIFF
--- a/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ActionDefinition.java
+++ b/rcljava_common/src/main/java/org/ros2/rcljava/interfaces/ActionDefinition.java
@@ -15,4 +15,8 @@
 
 package org.ros2.rcljava.interfaces;
 
-public interface ActionDefinition {}
+public interface ActionDefinition {
+  interface ActionGoal<T extends ActionDefinition> {}
+  interface ActionResult<T extends ActionDefinition> {}
+  interface ActionFeedback<T extends ActionDefinition> {}
+}

--- a/rosidl_generator_java/resource/action.java.em
+++ b/rosidl_generator_java/resource/action.java.em
@@ -58,6 +58,12 @@ import @(action_import);
 
 public class @(type_name) implements ActionDefinition {
 
+  public class Goal extends @(type_name)_Goal implements ActionGoal<@(type_name)> {}
+
+  public class Result extends @(type_name)_Result implements ActionResult<@(type_name)> {}
+
+  public class Feedback extends @(type_name)_Feedback implements ActionFeedback<@(type_name)> {}
+
   private static final Logger logger = LoggerFactory.getLogger(@(type_name).class);
 
   static {
@@ -70,10 +76,4 @@ public class @(type_name) implements ActionDefinition {
   }
 
   public static native long getActionTypeSupport();
-
-  public static final Class<@(type_name)_Goal> GoalType = @(type_name)_Goal.class;
-
-  public static final Class<@(type_name)_Result> ResultType = @(type_name)_Result.class;
-
-  public static final Class<@(type_name)_Feedback> FeedbackType = @(type_name)_Feedback.class;
 }

--- a/rosidl_generator_java/resource/msg.java.em
+++ b/rosidl_generator_java/resource/msg.java.em
@@ -38,7 +38,7 @@ import @('.'.join(member.type.namespaced_name()));
 @[  end if]@
 @[end for]@
 
-public final class @(type_name) implements MessageDefinition {
+public class @(type_name) implements MessageDefinition {
 
   private static final Logger logger = LoggerFactory.getLogger(@(type_name).class);
 


### PR DESCRIPTION
Implementing these interfaces in the code generation template makes it easier to pass around these types in a generic way.
Note, the 'final' modifier had to be removed from generated message types in order to extend goal, result, and feedback types in action definitions.