### PR TITLE
Remove dependency on Connext

### DIFF
--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -87,10 +87,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw.git
     version: dashing
-  ros2/rmw_connext:
-    type: git
-    url: https://github.com/ros2/rmw_connext.git
-    version: dashing
   ros2/rmw_cyclonedds:
     type: git
     url: https://github.com/ros2/rmw_cyclonedds.git
@@ -126,10 +122,6 @@ repositories:
   ros2/rosidl_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_typesupport.git
-    version: dashing
-  ros2/rosidl_typesupport_connext:
-    type: git
-    url: https://github.com/ros2/rosidl_typesupport_connext.git
     version: dashing
   ros2/rosidl_typesupport_fastrtps:
     type: git

--- a/rosidl_generator_java/package.xml
+++ b/rosidl_generator_java/package.xml
@@ -39,7 +39,6 @@
   <test_depend>rosidl_parser</test_depend>
   <!-- Duplicated from rosidl_default_generator in order to avoid a circular dependency. -->
   <test_depend>rosidl_typesupport_c</test_depend>
-  <test_depend>rosidl_typesupport_connext_c</test_depend>
   <test_depend>rosidl_typesupport_fastrtps_c</test_depend>
   <test_depend>rosidl_typesupport_introspection_c</test_depend>
   <test_depend>rosidl_typesupport_opensplice_c</test_depend>


### PR DESCRIPTION
- Remove test dependency on rosidl_typesupport_connext_c (f896ec5)
- Remove Connext packages from Android repos file (bbe8396)

Should resolve https://github.com/ros2-java/ros2_java/issues/160
Also related to https://github.com/ros2-java/ros2_java/issues/155