### PR TITLE
Remove dependency on OpenSplice

### DIFF
--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -99,10 +99,6 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
     version: dashing
-  ros2/rmw_opensplice:
-    type: git
-    url: https://github.com/ros2/rmw_opensplice.git
-    version: dashing
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
@@ -126,10 +122,6 @@ repositories:
   ros2/rosidl_typesupport_fastrtps:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: dashing
-  ros2/rosidl_typesupport_opensplice:
-    type: git
-    url: https://github.com/ros2/rosidl_typesupport_opensplice.git
     version: dashing
   ros2/test_interface_files:
     type: git


### PR DESCRIPTION
Removes both typesupport and rmw packages for OpenSplice for Android.

Fixes #162 