### PR TITLE
Use array instead of List for ROS message types

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
@@ -480,6 +480,8 @@ public class NodeImpl implements Node {
           new rcl_interfaces.msg.ListParametersResult();
 
       String separator = ".";
+      List<String> resultNames = new ArrayList<String>();
+      List<String> resultPrefixes = new ArrayList<String>();
       for (Map.Entry<String, ParameterVariant> entry : this.parameters.entrySet()) {
         boolean getAll =
             (prefixes.size() == 0)
@@ -500,16 +502,18 @@ public class NodeImpl implements Node {
           }
         }
         if (getAll || prefixMatches) {
-          result.getNames().add(entry.getKey());
+          resultNames.add(entry.getKey());
           int lastSeparator = entry.getKey().lastIndexOf(separator);
           if (-1 != lastSeparator) {
             String prefix = entry.getKey().substring(0, lastSeparator);
-            if (!result.getPrefixes().contains(prefix)) {
-              result.getPrefixes().add(prefix);
+            if (!resultPrefixes.contains(prefix)) {
+              resultPrefixes.add(prefix);
             }
           }
         }
       }
+      result.setNames(resultNames);
+      result.setPrefixes(resultPrefixes);
       return result;
     }
   }

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterVariant.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterVariant.java
@@ -94,7 +94,7 @@ public class ParameterVariant {
     this.value.setType(ParameterType.PARAMETER_STRING.getValue());
   }
 
-  public ParameterVariant(final String name, final List<Byte> byteArrayValue) {
+  public ParameterVariant(final String name, final byte[] byteArrayValue) {
     this.name = name;
     this.value = new rcl_interfaces.msg.ParameterValue();
     this.value.setByteArrayValue(byteArrayValue);
@@ -161,7 +161,7 @@ public class ParameterVariant {
     return this.value.getBoolValue();
   }
 
-  public final List<Byte> asByteArray() {
+  public final byte[] asByteArray() {
     if (getType() != ParameterType.PARAMETER_BYTE_ARRAY) {
       throw new IllegalArgumentException("Invalid type");
     }

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
@@ -114,16 +114,16 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
         request, new Consumer<Future<rcl_interfaces.srv.GetParameters_Response>>() {
           public void accept(final Future<rcl_interfaces.srv.GetParameters_Response> future) {
             List<ParameterVariant> parameterVariants = new ArrayList<ParameterVariant>();
-            List<rcl_interfaces.msg.ParameterValue> pvalues = null;
+            rcl_interfaces.msg.ParameterValue[] pvalues = new rcl_interfaces.msg.ParameterValue[0];
             try {
               pvalues = future.get().getValues();
             } catch (Exception e) {
               // TODO(esteve): do something
             }
-            for (int i = 0; i < pvalues.size(); i++) {
+            for (int i = 0; i < pvalues.length; i++) {
               rcl_interfaces.msg.Parameter parameter = new rcl_interfaces.msg.Parameter();
-              parameter.setName(request.getNames().get(i));
-              parameter.setValue(pvalues.get(i));
+              parameter.setName(request.getNames()[i]);
+              parameter.setValue(pvalues[i]);
               parameterVariants.add(ParameterVariant.fromParameter(parameter));
             }
             futureResult.set(parameterVariants);
@@ -151,13 +151,13 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
         request, new Consumer<Future<rcl_interfaces.srv.GetParameterTypes_Response>>() {
           public void accept(final Future<rcl_interfaces.srv.GetParameterTypes_Response> future) {
             List<ParameterType> parameterTypes = new ArrayList<ParameterType>();
-            List<Byte> pts = null;
+            byte[] pts = new byte[0];
             try {
               pts = future.get().getTypes();
             } catch (Exception e) {
               // TODO(esteve): do something
             }
-            for (Byte pt : pts) {
+            for (byte pt : pts) {
               parameterTypes.add(ParameterType.fromByte(pt));
             }
             futureResult.set(parameterTypes);
@@ -194,7 +194,7 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
           public void accept(final Future<rcl_interfaces.srv.SetParameters_Response> future) {
             List<rcl_interfaces.msg.SetParametersResult> setParametersResult = null;
             try {
-              setParametersResult = future.get().getResults();
+              setParametersResult = future.get().getResultsAsList();
             } catch (Exception e) {
               // TODO(esteve): do something
             }
@@ -297,7 +297,7 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
           public void accept(final Future<rcl_interfaces.srv.DescribeParameters_Response> future) {
             List<rcl_interfaces.msg.ParameterDescriptor> parameterDescriptors = null;
             try {
-              parameterDescriptors = future.get().getDescriptors();
+              parameterDescriptors = future.get().getDescriptorsAsList();
             } catch (Exception e) {
               // TODO(esteve): do something
             }

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterServiceImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterServiceImpl.java
@@ -48,7 +48,7 @@ public class ParameterServiceImpl implements ParameterService {
           public void accept(RMWRequestId rmwRequestId,
               rcl_interfaces.srv.GetParameters_Request request,
               rcl_interfaces.srv.GetParameters_Response response) {
-            List<ParameterVariant> values = node.getParameters(request.getNames());
+            List<ParameterVariant> values = node.getParameters(request.getNamesAsList());
             List<rcl_interfaces.msg.ParameterValue> pvalues =
                 new ArrayList<rcl_interfaces.msg.ParameterValue>();
             for (ParameterVariant pvariant : values) {
@@ -67,7 +67,7 @@ public class ParameterServiceImpl implements ParameterService {
           public void accept(RMWRequestId rmwRequestId,
               rcl_interfaces.srv.GetParameterTypes_Request request,
               rcl_interfaces.srv.GetParameterTypes_Response response) {
-            List<ParameterType> types = node.getParameterTypes(request.getNames());
+            List<ParameterType> types = node.getParameterTypes(request.getNamesAsList());
             List<Byte> ptypes = new ArrayList<Byte>();
             for (ParameterType type : types) {
               ptypes.add(type.getValue());
@@ -124,7 +124,7 @@ public class ParameterServiceImpl implements ParameterService {
               rcl_interfaces.srv.DescribeParameters_Request request,
               rcl_interfaces.srv.DescribeParameters_Response response) {
             List<rcl_interfaces.msg.ParameterDescriptor> descriptors =
-                node.describeParameters(request.getNames());
+                node.describeParameters(request.getNamesAsList());
             response.setDescriptors(descriptors);
           }
         },
@@ -139,7 +139,7 @@ public class ParameterServiceImpl implements ParameterService {
               rcl_interfaces.srv.ListParameters_Request request,
               rcl_interfaces.srv.ListParameters_Response response) {
             rcl_interfaces.msg.ListParametersResult result =
-                node.listParameters(request.getPrefixes(), request.getDepth());
+                node.listParameters(request.getPrefixesAsList(), request.getDepth());
             response.setResult(result);
           }
         },

--- a/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/node/NodeTest.java
@@ -252,8 +252,8 @@ public class NodeTest {
     rcljava.msg.BoundedArrayNested value = future.get();
     assertNotEquals(null, value.getPrimitiveValues());
 
-    rcljava.msg.Primitives primitivesValue1 = value.getPrimitiveValues().get(0);
-    rcljava.msg.Primitives primitivesValue2 = value.getPrimitiveValues().get(1);
+    rcljava.msg.Primitives primitivesValue1 = value.getPrimitiveValues()[0];
+    rcljava.msg.Primitives primitivesValue2 = value.getPrimitiveValues()[1];
 
     assertTrue(checkPrimitives(primitivesValue1, boolValue1, byteValue1, charValue1, float32Value1,
         float64Value1, int8Value1, uint8Value1, int16Value1, uint16Value1, int32Value1,
@@ -322,20 +322,20 @@ public class NodeTest {
 
     rcljava.msg.BoundedArrayPrimitives value = future.get();
 
-    assertEquals(boolValues, value.getBoolValues());
-    assertEquals(byteValues, value.getByteValues());
-    assertEquals(charValues, value.getCharValues());
-    assertEquals(float32Values, value.getFloat32Values());
-    assertEquals(float64Values, value.getFloat64Values());
-    assertEquals(int8Values, value.getInt8Values());
-    assertEquals(uint8Values, value.getUint8Values());
-    assertEquals(int16Values, value.getInt16Values());
-    assertEquals(uint16Values, value.getUint16Values());
-    assertEquals(int32Values, value.getInt32Values());
-    assertEquals(uint32Values, value.getUint32Values());
-    assertEquals(int64Values, value.getInt64Values());
-    assertEquals(uint64Values, value.getUint64Values());
-    assertEquals(stringValues, value.getStringValues());
+    assertEquals(boolValues, value.getBoolValuesAsList());
+    assertEquals(byteValues, value.getByteValuesAsList());
+    assertEquals(charValues, value.getCharValuesAsList());
+    assertEquals(float32Values, value.getFloat32ValuesAsList());
+    assertEquals(float64Values, value.getFloat64ValuesAsList());
+    assertEquals(int8Values, value.getInt8ValuesAsList());
+    assertEquals(uint8Values, value.getUint8ValuesAsList());
+    assertEquals(int16Values, value.getInt16ValuesAsList());
+    assertEquals(uint16Values, value.getUint16ValuesAsList());
+    assertEquals(int32Values, value.getInt32ValuesAsList());
+    assertEquals(uint32Values, value.getUint32ValuesAsList());
+    assertEquals(int64Values, value.getInt64ValuesAsList());
+    assertEquals(uint64Values, value.getUint64ValuesAsList());
+    assertEquals(stringValues, value.getStringValuesAsList());
 
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
@@ -414,8 +414,8 @@ public class NodeTest {
     rcljava.msg.DynamicArrayNested value = future.get();
     assertNotEquals(null, value.getPrimitiveValues());
 
-    rcljava.msg.Primitives primitivesValue1 = value.getPrimitiveValues().get(0);
-    rcljava.msg.Primitives primitivesValue2 = value.getPrimitiveValues().get(1);
+    rcljava.msg.Primitives primitivesValue1 = value.getPrimitiveValues()[0];
+    rcljava.msg.Primitives primitivesValue2 = value.getPrimitiveValues()[1];
 
     assertTrue(checkPrimitives(primitivesValue1, boolValue1, byteValue1, charValue1, float32Value1,
         float64Value1, int8Value1, uint8Value1, int16Value1, uint16Value1, int32Value1,
@@ -484,20 +484,20 @@ public class NodeTest {
 
     rcljava.msg.DynamicArrayPrimitives value = future.get();
 
-    assertEquals(boolValues, value.getBoolValues());
-    assertEquals(byteValues, value.getByteValues());
-    assertEquals(charValues, value.getCharValues());
-    assertEquals(float32Values, value.getFloat32Values());
-    assertEquals(float64Values, value.getFloat64Values());
-    assertEquals(int8Values, value.getInt8Values());
-    assertEquals(uint8Values, value.getUint8Values());
-    assertEquals(int16Values, value.getInt16Values());
-    assertEquals(uint16Values, value.getUint16Values());
-    assertEquals(int32Values, value.getInt32Values());
-    assertEquals(uint32Values, value.getUint32Values());
-    assertEquals(int64Values, value.getInt64Values());
-    assertEquals(uint64Values, value.getUint64Values());
-    assertEquals(stringValues, value.getStringValues());
+    assertEquals(boolValues, value.getBoolValuesAsList());
+    assertEquals(byteValues, value.getByteValuesAsList());
+    assertEquals(charValues, value.getCharValuesAsList());
+    assertEquals(float32Values, value.getFloat32ValuesAsList());
+    assertEquals(float64Values, value.getFloat64ValuesAsList());
+    assertEquals(int8Values, value.getInt8ValuesAsList());
+    assertEquals(uint8Values, value.getUint8ValuesAsList());
+    assertEquals(int16Values, value.getInt16ValuesAsList());
+    assertEquals(uint16Values, value.getUint16ValuesAsList());
+    assertEquals(int32Values, value.getInt32ValuesAsList());
+    assertEquals(uint32Values, value.getUint32ValuesAsList());
+    assertEquals(int64Values, value.getInt64ValuesAsList());
+    assertEquals(uint64Values, value.getUint64ValuesAsList());
+    assertEquals(stringValues, value.getStringValuesAsList());
 
     publisher.dispose();
     assertEquals(0, publisher.getHandle());
@@ -668,12 +668,12 @@ public class NodeTest {
     rcljava.msg.StaticArrayNested value = future.get();
     assertNotEquals(null, value.getPrimitiveValues());
 
-    assertEquals(4, value.getPrimitiveValues().size());
+    assertEquals(4, value.getPrimitiveValues().length);
 
-    rcljava.msg.Primitives primitivesValue1 = value.getPrimitiveValues().get(0);
-    rcljava.msg.Primitives primitivesValue2 = value.getPrimitiveValues().get(1);
-    rcljava.msg.Primitives primitivesValue3 = value.getPrimitiveValues().get(2);
-    rcljava.msg.Primitives primitivesValue4 = value.getPrimitiveValues().get(3);
+    rcljava.msg.Primitives primitivesValue1 = value.getPrimitiveValues()[0];
+    rcljava.msg.Primitives primitivesValue2 = value.getPrimitiveValues()[1];
+    rcljava.msg.Primitives primitivesValue3 = value.getPrimitiveValues()[2];
+    rcljava.msg.Primitives primitivesValue4 = value.getPrimitiveValues()[3];
 
     assertTrue(checkPrimitives(primitivesValue1, boolValue1, byteValue1, charValue1, float32Value1,
         float64Value1, int8Value1, uint8Value1, int16Value1, uint16Value1, int32Value1,
@@ -751,20 +751,20 @@ public class NodeTest {
 
     rcljava.msg.StaticArrayPrimitives value = future.get();
 
-    assertEquals(boolValues, value.getBoolValues());
-    assertEquals(byteValues, value.getByteValues());
-    assertEquals(charValues, value.getCharValues());
-    assertEquals(float32Values, value.getFloat32Values());
-    assertEquals(float64Values, value.getFloat64Values());
-    assertEquals(int8Values, value.getInt8Values());
-    assertEquals(uint8Values, value.getUint8Values());
-    assertEquals(int16Values, value.getInt16Values());
-    assertEquals(uint16Values, value.getUint16Values());
-    assertEquals(int32Values, value.getInt32Values());
-    assertEquals(uint32Values, value.getUint32Values());
-    assertEquals(int64Values, value.getInt64Values());
-    assertEquals(uint64Values, value.getUint64Values());
-    assertEquals(stringValues, value.getStringValues());
+    assertEquals(boolValues, value.getBoolValuesAsList());
+    assertEquals(byteValues, value.getByteValuesAsList());
+    assertEquals(charValues, value.getCharValuesAsList());
+    assertEquals(float32Values, value.getFloat32ValuesAsList());
+    assertEquals(float64Values, value.getFloat64ValuesAsList());
+    assertEquals(int8Values, value.getInt8ValuesAsList());
+    assertEquals(uint8Values, value.getUint8ValuesAsList());
+    assertEquals(int16Values, value.getInt16ValuesAsList());
+    assertEquals(uint16Values, value.getUint16ValuesAsList());
+    assertEquals(int32Values, value.getInt32ValuesAsList());
+    assertEquals(uint32Values, value.getUint32ValuesAsList());
+    assertEquals(int64Values, value.getInt64ValuesAsList());
+    assertEquals(uint64Values, value.getUint64ValuesAsList());
+    assertEquals(stringValues, value.getStringValuesAsList());
 
     publisher.dispose();
     assertEquals(0, publisher.getHandle());

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/AsyncParametersClientTest.java
@@ -15,6 +15,7 @@
 
 package org.ros2.rcljava.parameters;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -153,8 +154,8 @@ public class AsyncParametersClientTest {
     parametersClient.listParameters(
         Arrays.asList(new String[] {"foo", "bar"}), 10, new TestConsumer(future));
 
-    assertEquals(Arrays.asList(new String[] {"foo.first", "foo.second"}), future.get().getNames());
-    assertEquals(Arrays.asList(new String[] {"foo"}), future.get().getPrefixes());
+    assertArrayEquals(new String[] {"foo.first", "foo.second"}, future.get().getNames());
+    assertArrayEquals(new String[] {"foo"}, future.get().getPrefixes());
   }
 
   @Test

--- a/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
+++ b/rcljava/src/test/java/org/ros2/rcljava/parameters/SyncParametersClientTest.java
@@ -15,6 +15,7 @@
 
 package org.ros2.rcljava.parameters;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -130,9 +131,9 @@ public class SyncParametersClientTest {
     rcl_interfaces.msg.ListParametersResult parametersAndPrefixes =
         parametersClient.listParameters(Arrays.asList(new String[] {"foo", "bar"}), 10);
 
-    assertEquals(
-        parametersAndPrefixes.getNames(), Arrays.asList(new String[] {"foo.first", "foo.second"}));
-    assertEquals(parametersAndPrefixes.getPrefixes(), Arrays.asList(new String[] {"foo"}));
+    assertArrayEquals(
+        parametersAndPrefixes.getNames(), new String[] {"foo.first", "foo.second"});
+    assertEquals(parametersAndPrefixes.getPrefixes(), new String[] {"foo"});
   }
 
   @Test

--- a/rosidl_generator_java/resource/msg.cpp.em
+++ b/rosidl_generator_java/resource/msg.cpp.em
@@ -272,6 +272,9 @@ else:
 @[    else]@
     for (jint i = 0; i < _jarray_@(member.name)_size; ++i) {
       auto element = env->GetObjectArrayElement(_jarray_@(member.name)_obj, i);
+      if (element == nullptr) {
+        continue;
+      }
 @[      if isinstance(member.type.value_type, AbstractString)]@
       jstring _jfield_@(member.name)_value = static_cast<jstring>(element);
       if (_jfield_@(member.name)_value != nullptr) {
@@ -370,8 +373,10 @@ else:
     jni_signature = get_jni_signature(member.type)
 }@
 @[  if isinstance(member.type, AbstractNestedType)]@
-@[    if isinstance(member.type.value_type, (BasicType, AbstractGenericString))]@
+@[    if isinstance(member.type.value_type, BasicType)]@
   auto _jfield_@(member.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(member.name)", "[@(jni_signature)");
+@[    elif isinstance(member.type.value_type, AbstractGenericString)]@
+  auto _jfield_@(member.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(member.name)", "[Ljava/lang/String;");
 @[    else]@
   auto _jfield_@(member.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(member.name)", "[L@('/'.join(member.type.value_type.namespaced_name()));");
 @[    end if]@

--- a/rosidl_generator_java/resource/msg.java.em
+++ b/rosidl_generator_java/resource/msg.java.em
@@ -105,8 +105,40 @@ public final class @(type_name) implements MessageDefinition {
     return this;
   }
 
+  public final @(type_name) set@(convert_lower_case_underscore_to_camel_case(member.name))(final java.util.List<@(get_java_type(member.type, use_primitives=False))> @(member.name)) {
+@[    if isinstance(member.type, BoundedSequence)]@
+    if(@(member.name).size() > @(member.type.maximum_size)) {
+        throw new IllegalArgumentException("List too big, maximum size allowed: @(member.type.maximum_size)");
+    }
+@[    elif isinstance(member.type, Array)]@
+    if(@(member.name).size() != @(member.type.size)) {
+        throw new IllegalArgumentException("Invalid size for fixed array, must be exactly: @(member.type.size)");
+    }
+@[    end if]@
+@[    if isinstance(member.type.value_type, BasicType)]@
+    @(get_java_type(member.type, use_primitives=False))[] boxed_arr = @(member.name).toArray(new @(get_java_type(member.type, use_primitives=False))[]{});
+    @(get_java_type(member.type))[] unboxed_arr = new @(get_java_type(member.type))[@(member.name).size()];
+    for (int i = 0; i < @(member.name).size(); i++) {
+      unboxed_arr[i] = boxed_arr[i].@(get_java_type(member.type))Value();
+    }
+    this.@(member.name) = unboxed_arr;
+@[    else]@
+    this.@(member.name) = @(member.name).toArray(new @(get_java_type(member.type))[0]);
+@[    end if]@
+    return this;
+  }
+
   public final @(get_java_type(member.type))[] get@(convert_lower_case_underscore_to_camel_case(member.name))() {
     return this.@(member.name);
+  }
+
+  public final java.util.List<@(get_java_type(member.type, use_primitives=False))> get@(convert_lower_case_underscore_to_camel_case(member.name))AsList() {
+    // TODO(jacobperron): We could cache the List value for subsequent calls
+    java.util.List<@(get_java_type(member.type, use_primitives=False))> list = new java.util.ArrayList<@(get_java_type(member.type, use_primitives=False))>(this.@(member.name).length);
+    for (@(get_java_type(member.type)) element : this.@(member.name)) {
+      list.add(element);
+    }
+    return list;
   }
 @[  else]@
 @[    if member.has_annotation('default')]@

--- a/rosidl_generator_java/resource/msg.java.em
+++ b/rosidl_generator_java/resource/msg.java.em
@@ -80,22 +80,24 @@ public final class @(type_name) implements MessageDefinition {
 
 @[  if isinstance(member.type, AbstractNestedType)]@
 @[    if member.has_annotation('default')]@
-  private java.util.List<@(get_java_type(member.type, use_primitives=False))> @(member.name) = java.util.Arrays.asList(new @(get_java_type(member.type, use_primitives=False))[] @(value_to_java(member.type, member.get_annotation_value('default')['value'])));
+  private @(get_java_type(member.type))[] @(member.name) = new @(get_java_type(member.type))[] @(value_to_java(member.type, member.get_annotation_value('default')['value']));
 @[    else]@
 @[      if isinstance(member.type, Array)]@
-  private java.util.List<@(get_java_type(member.type, use_primitives=False))> @(member.name);
+  private @(get_java_type(member.type))[] @(member.name) = new @(get_java_type(member.type))[@(member.type.size)];
+@[      elif isinstance(member.type, BoundedSequence)]@
+  private @(get_java_type(member.type))[] @(member.name) = new @(get_java_type(member.type))[]{};
 @[      else]@
-  private java.util.List<@(get_java_type(member.type, use_primitives=False))> @(member.name) = new java.util.ArrayList<@(get_java_type(member.type, use_primitives=False))>();
+  private @(get_java_type(member.type))[] @(member.name);
 @[      end if]@
 @[    end if]@
 
-  public final @(type_name) set@(convert_lower_case_underscore_to_camel_case(member.name))(final java.util.List<@(get_java_type(member.type, use_primitives=False))> @(member.name)) {
+  public final @(type_name) set@(convert_lower_case_underscore_to_camel_case(member.name))(final @(get_java_type(member.type))[] @(member.name)) {
 @[    if isinstance(member.type, BoundedSequence)]@
-    if(@(member.name).size() > @(member.type.maximum_size)) {
-        throw new IllegalArgumentException("List too big, maximum size allowed: @(member.type.maximum_size)");
+    if(@(member.name).length > @(member.type.maximum_size)) {
+        throw new IllegalArgumentException("Array too big, maximum size allowed: @(member.type.maximum_size)");
     }
 @[    elif isinstance(member.type, Array)]@
-    if(@(member.name).size() != @(member.type.size)) {
+    if(@(member.name).length != @(member.type.size)) {
         throw new IllegalArgumentException("Invalid size for fixed array, must be exactly: @(member.type.size)");
     }
 @[    end if]@
@@ -103,17 +105,7 @@ public final class @(type_name) implements MessageDefinition {
     return this;
   }
 
-@[    if isinstance(member.type.value_type, (BasicType, AbstractGenericString))]@
-  public final @(type_name) set@(convert_lower_case_underscore_to_camel_case(member.name))(final @(get_java_type(member.type, use_primitives=True))[] @(member.name)) {
-    java.util.List<@(get_java_type(member.type, use_primitives=False))> @(member.name)_tmp = new java.util.ArrayList<@(get_java_type(member.type, use_primitives=False))>();
-    for(@(get_java_type(member.type, use_primitives=True)) @(member.name)_value : @(member.name)) {
-      @(member.name)_tmp.add(@(member.name)_value);
-    }
-    return set@(convert_lower_case_underscore_to_camel_case(member.name))(@(member.name)_tmp);
-  }
-@[    end if]@
-
-  public final java.util.List<@(get_java_type(member.type, use_primitives=False))> get@(convert_lower_case_underscore_to_camel_case(member.name))() {
+  public final @(get_java_type(member.type))[] get@(convert_lower_case_underscore_to_camel_case(member.name))() {
     return this.@(member.name);
   }
 @[  else]@

--- a/rosidl_generator_java/resource/msg.java.em
+++ b/rosidl_generator_java/resource/msg.java.em
@@ -84,10 +84,8 @@ public final class @(type_name) implements MessageDefinition {
 @[    else]@
 @[      if isinstance(member.type, Array)]@
   private @(get_java_type(member.type))[] @(member.name) = new @(get_java_type(member.type))[@(member.type.size)];
-@[      elif isinstance(member.type, BoundedSequence)]@
-  private @(get_java_type(member.type))[] @(member.name) = new @(get_java_type(member.type))[]{};
 @[      else]@
-  private @(get_java_type(member.type))[] @(member.name);
+  private @(get_java_type(member.type))[] @(member.name) = new @(get_java_type(member.type))[]{};
 @[      end if]@
 @[    end if]@
 

--- a/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
+++ b/rosidl_generator_java/src/test/java/org/ros2/generator/InterfacesTest.java
@@ -15,6 +15,7 @@
 
 package org.ros2.generator;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,95 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class InterfacesTest {
+  public class ListFixtureData {
+    public boolean[] boolArr = new boolean[]{true, false, true};
+    public List<Boolean> boolList = Arrays.asList(true, false, true);
+    public boolean[] boolArrShort = new boolean[]{false};
+    public List<Boolean> boolListShort = Arrays.asList(false);
+    public byte[] byteArr = new byte[]{(byte) 0, (byte) 1, (byte) 255};
+    public List<Byte> byteList = Arrays.asList((byte) 0, (byte) 1, (byte) 255);
+    public byte[] byteArrShort = new byte[]{1};
+    public List<Byte> byteListShort = Arrays.asList((byte) 1);
+    public byte[] charArr = new byte[]{(byte) ' ', (byte) 'a', (byte) 'Z'};
+    public List<Byte> charList = Arrays.asList(new Byte((byte) ' '), new Byte((byte) 'a'), new Byte((byte) 'Z'));
+    public byte[] charArrShort = new byte[]{(byte) 'z', (byte) 'A'};
+    public List<Byte> charListShort = Arrays.asList(new Byte((byte) 'z'), new Byte((byte) 'A'));
+    public float[] float32Arr = new float[]{0.0f, -1.125f, 1.125f};
+    public List<Float> float32List = Arrays.asList(0.0f, -1.125f, 1.125f);
+    public float[] float32ArrShort = new float[]{1.125f, -1.125f};
+    public List<Float> float32ListShort = Arrays.asList(1.125f, -1.125f);
+    public double[] float64Arr = new double[]{0.0, -3.1415, 3.1415};
+    public List<Double> float64List = Arrays.asList(0.0, -3.1415, 3.1415);
+    public double[] float64ArrShort = new double[]{3.1415, -3.1415};
+    public List<Double> float64ListShort = Arrays.asList(3.1415, -3.1415);
+    public byte[] int8Arr = new byte[]{0, -128, 127};
+    public List<Byte> int8List = Arrays.asList((byte) 0, (byte) -128, (byte) 127);
+    public byte[] int8ArrShort = new byte[]{127, -128};
+    public List<Byte> int8ListShort = Arrays.asList((byte) 127, (byte) -128);
+    public byte[] uint8Arr = new byte[]{(byte) 0, (byte) 1, (byte) 255};
+    public List<Byte> uint8List = Arrays.asList((byte) 0, (byte) 1, (byte) 255);
+    public byte[] uint8ArrShort = new byte[]{(byte) 255, (byte) 1};
+    public List uint8ListShort = Arrays.asList((byte) 255, (byte) 1);
+    public short[] int16Arr = new short[]{0, -32768, 32767};
+    public List<Short> int16List = Arrays.asList((short) 0, (short) -32768, (short) 32767);
+    public short[] int16ArrShort = new short[]{32767, -32768};
+    public List<Short> int16ListShort = Arrays.asList((short) 32767, (short) -32768);
+    public short[] uint16Arr = new short[]{(short) 0, (short) 1, (short) 65535};
+    public List<Short> uint16List = Arrays.asList((short) 0, (short) 1, (short) 65535);
+    public short[] uint16ArrShort = new short[]{(short) 0, (short) 1, (short) 65535};
+    public List<Short> uint16ListShort = Arrays.asList((short) 0, (short) 1, (short) 65535);
+    public int[] int32Arr = new int[]{0, -2147483648, 2147483647};
+    public List<Integer> int32List = Arrays.asList(0, -2147483648, 2147483647);
+    public int[] int32ArrShort = new int[]{2147483647, -2147483648};
+    public List<Integer> int32ListShort = Arrays.asList(2147483647, -2147483648);
+    public int[] uint32Arr = new int[]{0, 1, (int) 4294967295L};
+    public List<Integer> uint32List = Arrays.asList(0, 1, (int) 4294967295L);
+    public int[] uint32ArrShort = new int[]{(int) 4294967295L, 1};
+    public List<Integer> uint32ListShort = Arrays.asList((int) 4294967295L, 1);
+    public long[] int64Arr = new long[]{0L, -9223372036854775808L, 9223372036854775807L};
+    public List<Long> int64List = Arrays.asList(0L, -9223372036854775808L, 9223372036854775807L);
+    public long[] int64ArrShort = new long[]{0L, -9223372036854775808L, 9223372036854775807L};
+    public List<Long> int64ListShort = Arrays.asList(0L, -9223372036854775808L, 9223372036854775807L);
+    public long[] uint64Arr = new long[]{0L, 1L, -1L};
+    public List<Long> uint64List = Arrays.asList(0L, 1L, -1L);
+    public long[] uint64ArrShort = new long[]{0L, 1L, -1L};
+    public List<Long> uint64ListShort = Arrays.asList(0L, 1L, -1L);
+    public String[] stringArr = new String[]{"", "min value", "max_value"};
+    public List stringList = Arrays.asList(stringArr);
+    public String[] stringArrShort = new String[]{"max_value", ""};
+    public List stringListShort = Arrays.asList(stringArrShort);
+    private rosidl_generator_java.msg.BasicTypes basicTypes = new rosidl_generator_java.msg.BasicTypes();
+    public rosidl_generator_java.msg.BasicTypes[] basicTypesArr =
+        new rosidl_generator_java.msg.BasicTypes[] {basicTypes, basicTypes, basicTypes};
+    public List<rosidl_generator_java.msg.BasicTypes> basicTypesList = Arrays.asList(basicTypesArr);
+    public rosidl_generator_java.msg.BasicTypes[] basicTypesArrShort =
+        new rosidl_generator_java.msg.BasicTypes[] {basicTypes};
+    public List<rosidl_generator_java.msg.BasicTypes> basicTypesListShort = Arrays.asList(basicTypesArrShort);
+    public rosidl_generator_java.msg.BasicTypes[] basicTypesArrLong =
+        new rosidl_generator_java.msg.BasicTypes[] {basicTypes, basicTypes, basicTypes, basicTypes};
+    public List<rosidl_generator_java.msg.BasicTypes> basicTypesListLong = Arrays.asList(basicTypesArrLong);
+    private rosidl_generator_java.msg.Constants constants = new rosidl_generator_java.msg.Constants();
+    public rosidl_generator_java.msg.Constants[] constantsArr =
+        new rosidl_generator_java.msg.Constants[] {constants, constants, constants};
+    public List<rosidl_generator_java.msg.Constants> constantsList = Arrays.asList(constantsArr);
+    public rosidl_generator_java.msg.Constants[] constantsArrShort =
+        new rosidl_generator_java.msg.Constants[] {constants};
+    public List<rosidl_generator_java.msg.Constants> constantsListShort = Arrays.asList(constantsArrShort);
+    public rosidl_generator_java.msg.Constants[] constantsArrLong =
+        new rosidl_generator_java.msg.Constants[] {constants, constants, constants, constants};
+    public List<rosidl_generator_java.msg.Constants> constantsListLong = Arrays.asList(constantsArrLong);
+    private rosidl_generator_java.msg.Defaults defaults = new rosidl_generator_java.msg.Defaults();
+    public rosidl_generator_java.msg.Defaults[] defaultsArr =
+        new rosidl_generator_java.msg.Defaults[] {defaults, defaults, defaults};
+    public List<rosidl_generator_java.msg.Defaults> defaultsList = Arrays.asList(defaultsArr);
+    public rosidl_generator_java.msg.Defaults[] defaultsArrShort =
+        new rosidl_generator_java.msg.Defaults[] {defaults};
+    public List<rosidl_generator_java.msg.Defaults> defaultsListShort = Arrays.asList(defaultsArrShort);
+    public rosidl_generator_java.msg.Defaults[] defaultsArrLong =
+        new rosidl_generator_java.msg.Defaults[] {defaults, defaults, defaults, defaults};
+    public List<rosidl_generator_java.msg.Defaults> defaultsListLong = Arrays.asList(defaultsArrLong);
+  }
+
   @BeforeClass
   public static void setupOnce() {
     try
@@ -204,106 +294,135 @@ public class InterfacesTest {
   @Test
   public final void testArrays() {
     rosidl_generator_java.msg.Arrays arrays = new rosidl_generator_java.msg.Arrays();
+    ListFixtureData fixture = new ListFixtureData();
 
     // This value should not change and is asserted at end of test
     arrays.setAlignmentCheck(42);
 
     // Test setting/getting fixed length arrays of primitive types
-    List boolList = Arrays.asList(true, false, true);
-    arrays.setBoolValues(boolList);
-    assertEquals(boolList, arrays.getBoolValues());
+    arrays.setBoolValues(fixture.boolList);
+    assertArrayEquals(fixture.boolArr, arrays.getBoolValues());
+    assertEquals(fixture.boolList, arrays.getBoolValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setBoolValues(new boolean[]{true, false, true, false}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setBoolValues(Arrays.asList(true, false, true, false)));
-    List byteList = Arrays.asList((byte) 0, (byte) 1, (byte) 255);
-    arrays.setByteValues(byteList);
-    assertEquals(byteList, arrays.getByteValues());
+    arrays.setByteValues(fixture.byteList);
+    assertArrayEquals(fixture.byteArr, arrays.getByteValues());
+    assertEquals(fixture.byteList, arrays.getByteValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setByteValues(new byte[]{(byte) 1, (byte) 2}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setByteValues(Arrays.asList((byte) 1, (byte) 2)));
-    List charList = Arrays.asList(' ', 'a', 'Z');
-    arrays.setCharValues(charList);
-    assertEquals(charList, arrays.getCharValues());
+    arrays.setCharValues(fixture.charList);
+    assertArrayEquals(fixture.charArr, arrays.getCharValues());
+    assertEquals(fixture.charList, arrays.getCharValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setCharValues(new byte[]{(byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd'}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setCharValues(Arrays.asList((byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd')));
-    List float32List = Arrays.asList(0.0f, -1.125f, 1.125f);
-    arrays.setFloat32Values(float32List);
-    assertEquals(float32List, arrays.getFloat32Values());
+    arrays.setFloat32Values(fixture.float32List);
+    assertTrue(Arrays.equals(fixture.float32Arr, arrays.getFloat32Values()));
+    assertEquals(fixture.float32List, arrays.getFloat32ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setFloat32Values(new float[]{1.0f, 2.0f}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setFloat32Values(Arrays.asList(1.0f, 2.0f)));
-    List float64List = Arrays.asList(0.0f, -3.1415, 3.1415);
-    arrays.setFloat64Values(float64List);
-    assertEquals(float64List, arrays.getFloat64Values());
+    arrays.setFloat64Values(fixture.float64List);
+    assertTrue(Arrays.equals(fixture.float64Arr, arrays.getFloat64Values()));
+    assertEquals(fixture.float64List, arrays.getFloat64ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setFloat64Values(new double[]{1.0, 2.0, 3.0, 4.0}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setFloat64Values(Arrays.asList(1.0, 2.0, 3.0, 4.0)));
-    List int8List = Arrays.asList(0, -128, 127);
-    arrays.setInt8Values(int8List);
-    assertEquals(int8List, arrays.getInt8Values());
+    arrays.setInt8Values(fixture.int8List);
+    assertArrayEquals(fixture.int8Arr, arrays.getInt8Values());
+    assertEquals(fixture.int8List, arrays.getInt8ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () ->arrays.setInt8Values(new byte[]{(byte) 1, (byte) 2}));
     assertThrows(IllegalArgumentException.class,
       () ->arrays.setInt8Values(Arrays.asList((byte) 1, (byte) 2)));
-    List uint8List = Arrays.asList(0, 1, 255);
-    arrays.setUint8Values(uint8List);
-    assertEquals(uint8List, arrays.getUint8Values());
+    arrays.setUint8Values(fixture.uint8List);
+    assertArrayEquals(fixture.uint8Arr, arrays.getUint8Values());
+    assertEquals(fixture.uint8List, arrays.getUint8ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setUint8Values(new byte[]{(byte) 1, (byte) 2, (byte) 3, (byte) 4}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setUint8Values(Arrays.asList((byte) 1, (byte) 2, (byte) 3, (byte) 4)));
-    List int16List = Arrays.asList(0, -32768, 32767);
-    arrays.setInt16Values(int16List);
-    assertEquals(int16List, arrays.getInt16Values());
+    arrays.setInt16Values(fixture.int16List);
+    assertTrue(Arrays.equals(fixture.int16Arr, arrays.getInt16Values()));
+    assertEquals(fixture.int16List, arrays.getInt16ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setInt16Values(new short[]{(short) 1, (short) 2}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setInt16Values(Arrays.asList((short) 1, (short) 2)));
-    List uint16List = Arrays.asList(0, 1, 65535);
-    arrays.setUint16Values(uint16List);
-    assertEquals(uint16List, arrays.getUint16Values());
+    arrays.setUint16Values(fixture.uint16List);
+    assertTrue(Arrays.equals(fixture.uint16Arr, arrays.getUint16Values()));
+    assertEquals(fixture.uint16List, arrays.getUint16ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setUint16Values(new short[]{(short) 1, (short) 2, (short) 3, (short) 4}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setUint16Values(Arrays.asList((short) 1, (short) 2, (short) 3, (short) 4)));
-    List int32List = Arrays.asList(0, -2147483648, 2147483647);
-    arrays.setInt32Values(int32List);
-    assertEquals(int32List, arrays.getInt32Values());
+    arrays.setInt32Values(fixture.int32List);
+    assertArrayEquals(fixture.int32Arr, arrays.getInt32Values());
+    assertEquals(fixture.int32List, arrays.getInt32ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setInt32Values(new int[]{1, 2}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setInt32Values(Arrays.asList(1, 2)));
-    List uint32List = Arrays.asList(0, 1, 4294967295L);
-    arrays.setUint32Values(uint32List);
-    assertEquals(uint32List, arrays.getUint32Values());
+    arrays.setUint32Values(fixture.uint32List);
+    assertArrayEquals(fixture.uint32Arr, arrays.getUint32Values());
+    assertEquals(fixture.uint32List, arrays.getUint32ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setUint32Values(new int[]{1, 2, 3, 4}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setUint32Values(Arrays.asList(1, 2, 3, 4)));
-    List int64List = Arrays.asList(0, -9223372036854775808L, 9223372036854775807L);
-    arrays.setInt64Values(int64List);
-    assertEquals(int64List, arrays.getInt64Values());
+    arrays.setInt64Values(fixture.int64List);
+    assertArrayEquals(fixture.int64Arr, arrays.getInt64Values());
+    assertEquals(fixture.int64List, arrays.getInt64ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setInt64Values(new long[]{1L, 2L}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setInt64Values(Arrays.asList(1L, 2L)));
-    List uint64List = Arrays.asList(0, 1, -1);
-    arrays.setUint64Values(uint64List);
-    assertEquals(uint64List, arrays.getUint64Values());
+    arrays.setUint64Values(fixture.uint64List);
+    assertArrayEquals(fixture.uint64Arr, arrays.getUint64Values());
+    assertEquals(fixture.uint64List, arrays.getUint64ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () ->arrays.setUint64Values(new long[]{1L, 2L, 3L, 4L}));
     assertThrows(IllegalArgumentException.class,
       () ->arrays.setUint64Values(Arrays.asList(1L, 2L, 3L, 4L)));
 
     // Test setting/getting fixed length arrays of strings
-    List stringList = Arrays.asList("", "min value", "max_value");
-    arrays.setStringValues(stringList);
-    assertEquals(stringList, arrays.getStringValues());
+    arrays.setStringValues(fixture.stringList);
+    assertArrayEquals(fixture.stringArr, arrays.getStringValues());
+    assertEquals(fixture.stringList, arrays.getStringValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setStringValues(new String[]{"too", "few"}));
     assertThrows(IllegalArgumentException.class,
       () -> arrays.setStringValues(Arrays.asList("too", "few")));
 
     // Test setting/getting fixed length arrays of nested types
-    rosidl_generator_java.msg.BasicTypes basicTypes = new rosidl_generator_java.msg.BasicTypes();
-    List basicTypesList = Arrays.asList(
-        new rosidl_generator_java.msg.BasicTypes[] {basicTypes, basicTypes, basicTypes});
-    arrays.setBasicTypesValues(basicTypesList);
-    assertEquals(basicTypesList, arrays.getBasicTypesValues());
+    arrays.setBasicTypesValues(fixture.basicTypesList);
+    assertArrayEquals(fixture.basicTypesArr, arrays.getBasicTypesValues());
+    assertEquals(fixture.basicTypesList, arrays.getBasicTypesValuesAsList());
     assertThrows(IllegalArgumentException.class,
-      () -> arrays.setBasicTypesValues(Arrays.asList(new rosidl_generator_java.msg.BasicTypes[] {basicTypes})));
-    rosidl_generator_java.msg.Constants constants = new rosidl_generator_java.msg.Constants();
-    List constantsList = Arrays.asList(
-        new rosidl_generator_java.msg.Constants[] {constants, constants, constants});
-    arrays.setConstantsValues(constantsList);
-    assertEquals(constantsList, arrays.getConstantsValues());
+      () -> arrays.setBasicTypesValues(fixture.basicTypesArrShort));
     assertThrows(IllegalArgumentException.class,
-      () -> arrays.setConstantsValues(Arrays.asList(new rosidl_generator_java.msg.Constants[] {constants})));
-    rosidl_generator_java.msg.Defaults defaults = new rosidl_generator_java.msg.Defaults();
-    List defaultsList = Arrays.asList(
-        new rosidl_generator_java.msg.Defaults[] {defaults, defaults, defaults});
-    arrays.setDefaultsValues(defaultsList);
-    assertEquals(defaultsList, arrays.getDefaultsValues());
+      () -> arrays.setBasicTypesValues(fixture.basicTypesListShort));
+    arrays.setConstantsValues(fixture.constantsList);
+    assertArrayEquals(fixture.constantsArr, arrays.getConstantsValues());
+    assertEquals(fixture.constantsList, arrays.getConstantsValuesAsList());
     assertThrows(IllegalArgumentException.class,
-      () -> arrays.setDefaultsValues(Arrays.asList(new rosidl_generator_java.msg.Defaults[] {defaults})));
+      () -> arrays.setConstantsValues(fixture.constantsArrShort));
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setConstantsValues(fixture.constantsListShort));
+    arrays.setDefaultsValues(fixture.defaultsList);
+    assertArrayEquals(fixture.defaultsArr, arrays.getDefaultsValues());
+    assertEquals(fixture.defaultsList, arrays.getDefaultsValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setDefaultsValues(fixture.defaultsArrShort));
+    assertThrows(IllegalArgumentException.class,
+      () -> arrays.setDefaultsValues(fixture.defaultsListShort));
 
     assertEquals(42, arrays.getAlignmentCheck());
   }
@@ -311,163 +430,184 @@ public class InterfacesTest {
   @Test
   public final void testBoundedSequences() {
     rosidl_generator_java.msg.BoundedSequences bounded_seq = new rosidl_generator_java.msg.BoundedSequences();
+    ListFixtureData fixture = new ListFixtureData();
 
     // This value should not change and is asserted at end of test
     bounded_seq.setAlignmentCheck(42);
 
     // Test setting/getting fixed length bounded_seq of primitive types
-    List boolList = Arrays.asList(true, false, true);
-    bounded_seq.setBoolValues(boolList);
-    assertEquals(boolList, bounded_seq.getBoolValues());
-    List boolListShort = Arrays.asList(false);
-    bounded_seq.setBoolValues(boolListShort);
-    assertEquals(boolListShort, bounded_seq.getBoolValues());
+    bounded_seq.setBoolValues(fixture.boolList);
+    assertArrayEquals(fixture.boolArr, bounded_seq.getBoolValues());
+    assertEquals(fixture.boolList, bounded_seq.getBoolValuesAsList());
+    bounded_seq.setBoolValues(fixture.boolListShort);
+    assertArrayEquals(fixture.boolArrShort, bounded_seq.getBoolValues());
+    assertEquals(fixture.boolListShort, bounded_seq.getBoolValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setBoolValues(new boolean[]{true, false, true, false}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setBoolValues(Arrays.asList(true, false, true, false)));
-    List byteList = Arrays.asList((byte) 0, (byte) 1, (byte) 255);
-    bounded_seq.setByteValues(byteList);
-    assertEquals(byteList, bounded_seq.getByteValues());
-    List byteListShort = Arrays.asList((byte) 1);
-    bounded_seq.setByteValues(byteListShort);
-    assertEquals(byteListShort, bounded_seq.getByteValues());
+    bounded_seq.setByteValues(fixture.byteList);
+    assertArrayEquals(fixture.byteArr, bounded_seq.getByteValues());
+    assertEquals(fixture.byteList, bounded_seq.getByteValuesAsList());
+    bounded_seq.setByteValues(fixture.byteListShort);
+    assertArrayEquals(fixture.byteArrShort, bounded_seq.getByteValues());
+    assertEquals(fixture.byteListShort, bounded_seq.getByteValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setByteValues(new byte[]{(byte) 1, (byte) 2, (byte) 3, (byte) 4}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setByteValues(Arrays.asList((byte) 1, (byte) 2, (byte) 3, (byte) 4)));
-    List charList = Arrays.asList(' ', 'a', 'Z');
-    bounded_seq.setCharValues(charList);
-    assertEquals(charList, bounded_seq.getCharValues());
-    List charListShort = Arrays.asList('z', 'A');
-    bounded_seq.setCharValues(charListShort);
-    assertEquals(charListShort, bounded_seq.getCharValues());
+    bounded_seq.setCharValues(fixture.charList);
+    assertArrayEquals(fixture.charArr, bounded_seq.getCharValues());
+    assertEquals(fixture.charList, bounded_seq.getCharValuesAsList());
+    bounded_seq.setCharValues(fixture.charListShort);
+    assertArrayEquals(fixture.charArrShort, bounded_seq.getCharValues());
+    assertEquals(fixture.charListShort, bounded_seq.getCharValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setCharValues(new byte[]{(byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd'}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setCharValues(Arrays.asList((byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd')));
-    List float32List = Arrays.asList(0.0f, -1.125f, 1.125f);
-    bounded_seq.setFloat32Values(float32List);
-    assertEquals(float32List, bounded_seq.getFloat32Values());
-    List float32ListShort = Arrays.asList(1.125f, -1.125f);
-    bounded_seq.setFloat32Values(float32ListShort);
-    assertEquals(float32ListShort, bounded_seq.getFloat32Values());
+    bounded_seq.setFloat32Values(fixture.float32List);
+    assertTrue(Arrays.equals(fixture.float32Arr, bounded_seq.getFloat32Values()));
+    assertEquals(fixture.float32List, bounded_seq.getFloat32ValuesAsList());
+    bounded_seq.setFloat32Values(fixture.float32ListShort);
+    assertTrue(Arrays.equals(fixture.float32ArrShort, bounded_seq.getFloat32Values()));
+    assertEquals(fixture.float32ListShort, bounded_seq.getFloat32ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setFloat32Values(new float[]{1.0f, 2.0f, 3.0f, 4.0f}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setFloat32Values(Arrays.asList(1.0f, 2.0f, 3.0f, 4.0f)));
-    List float64List = Arrays.asList(0.0f, -3.1415, 3.1415);
-    bounded_seq.setFloat64Values(float64List);
-    assertEquals(float64List, bounded_seq.getFloat64Values());
-    List float64ListShort = Arrays.asList(3.1415, -3.1415);
-    bounded_seq.setFloat64Values(float64ListShort);
-    assertEquals(float64ListShort, bounded_seq.getFloat64Values());
+    bounded_seq.setFloat64Values(fixture.float64List);
+    assertTrue(Arrays.equals(fixture.float64Arr, bounded_seq.getFloat64Values()));
+    assertEquals(fixture.float64List, bounded_seq.getFloat64ValuesAsList());
+    bounded_seq.setFloat64Values(fixture.float64ListShort);
+    assertTrue(Arrays.equals(fixture.float64ArrShort, bounded_seq.getFloat64Values()));
+    assertEquals(fixture.float64ListShort, bounded_seq.getFloat64ValuesAsList());
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setFloat64Values(Arrays.asList(1.0, 2.0, 3.0, 4.0)));
-    List int8List = Arrays.asList(0, -128, 127);
-    bounded_seq.setInt8Values(int8List);
-    assertEquals(int8List, bounded_seq.getInt8Values());
-    List int8ListShort = Arrays.asList(127, -128);
-    bounded_seq.setInt8Values(int8ListShort);
-    assertEquals(int8ListShort, bounded_seq.getInt8Values());
+    bounded_seq.setInt8Values(fixture.int8List);
+    assertArrayEquals(fixture.int8Arr, bounded_seq.getInt8Values());
+    assertEquals(fixture.int8List, bounded_seq.getInt8ValuesAsList());
+    bounded_seq.setInt8Values(fixture.int8ListShort);
+    assertArrayEquals(fixture.int8ArrShort, bounded_seq.getInt8Values());
+    assertEquals(fixture.int8ListShort, bounded_seq.getInt8ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setInt8Values(new byte[]{(byte) 1, (byte) 2, (byte) 3, (byte) 4}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setInt8Values(Arrays.asList((byte) 1, (byte) 2, (byte) 3, (byte) 4)));
-    List uint8List = Arrays.asList(0, 1, 255);
-    bounded_seq.setUint8Values(uint8List);
-    assertEquals(uint8List, bounded_seq.getUint8Values());
-    List uint8ListShort = Arrays.asList(255, 1);
-    bounded_seq.setUint8Values(uint8ListShort);
-    assertEquals(uint8ListShort, bounded_seq.getUint8Values());
+    bounded_seq.setUint8Values(fixture.uint8List);
+    assertArrayEquals(fixture.uint8Arr, bounded_seq.getUint8Values());
+    assertEquals(fixture.uint8List, bounded_seq.getUint8ValuesAsList());
+    bounded_seq.setUint8Values(fixture.uint8ListShort);
+    assertArrayEquals(fixture.uint8ArrShort, bounded_seq.getUint8Values());
+    assertEquals(fixture.uint8ListShort, bounded_seq.getUint8ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setUint8Values(new byte[]{(byte) 1, (byte) 2, (byte) 3, (byte) 4}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setUint8Values(Arrays.asList((byte) 1, (byte) 2, (byte) 3, (byte) 4)));
-    List int16List = Arrays.asList(0, -32768, 32767);
-    bounded_seq.setInt16Values(int16List);
-    assertEquals(int16List, bounded_seq.getInt16Values());
-    List int16ListShort = Arrays.asList(32767, -32768);
-    bounded_seq.setInt16Values(int16ListShort);
-    assertEquals(int16ListShort, bounded_seq.getInt16Values());
+    bounded_seq.setInt16Values(fixture.int16List);
+    assertTrue(Arrays.equals(fixture.int16Arr, bounded_seq.getInt16Values()));
+    assertEquals(fixture.int16List, bounded_seq.getInt16ValuesAsList());
+    bounded_seq.setInt16Values(fixture.int16ListShort);
+    assertTrue(Arrays.equals(fixture.int16ArrShort, bounded_seq.getInt16Values()));
+    assertEquals(fixture.int16ListShort, bounded_seq.getInt16ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setInt16Values(new short[]{(short) 1, (short) 2, (short) 3, (short) 4}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setInt16Values(Arrays.asList((short) 1, (short) 2, (short) 3, (short) 4)));
-    List uint16List = Arrays.asList(0, 1, 65535);
-    bounded_seq.setUint16Values(uint16List);
-    assertEquals(uint16List, bounded_seq.getUint16Values());
-    List uint16ListShort = Arrays.asList(0, 1, 65535);
-    bounded_seq.setUint16Values(uint16ListShort);
-    assertEquals(uint16ListShort, bounded_seq.getUint16Values());
+    bounded_seq.setUint16Values(fixture.uint16List);
+    assertTrue(Arrays.equals(fixture.uint16Arr, bounded_seq.getUint16Values()));
+    assertEquals(fixture.uint16List, bounded_seq.getUint16ValuesAsList());
+    bounded_seq.setUint16Values(fixture.uint16ListShort);
+    assertTrue(Arrays.equals(fixture.uint16ArrShort, bounded_seq.getUint16Values()));
+    assertEquals(fixture.uint16ListShort, bounded_seq.getUint16ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setUint16Values(new short[]{(short) 1, (short) 2, (short) 3, (short) 4}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setUint16Values(Arrays.asList((short) 1, (short) 2, (short) 3, (short) 4)));
-    List int32List = Arrays.asList(0, -2147483648, 2147483647);
-    bounded_seq.setInt32Values(int32List);
-    assertEquals(int32List, bounded_seq.getInt32Values());
-    List int32ListShort = Arrays.asList(2147483647, -2147483648);
-    bounded_seq.setInt32Values(int32ListShort);
-    assertEquals(int32ListShort, bounded_seq.getInt32Values());
+    bounded_seq.setInt32Values(fixture.int32List);
+    assertArrayEquals(fixture.int32Arr, bounded_seq.getInt32Values());
+    assertEquals(fixture.int32List, bounded_seq.getInt32ValuesAsList());
+    bounded_seq.setInt32Values(fixture.int32ListShort);
+    assertArrayEquals(fixture.int32ArrShort, bounded_seq.getInt32Values());
+    assertEquals(fixture.int32ListShort, bounded_seq.getInt32ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setInt32Values(new int[]{1, 2, 3, 4}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setInt32Values(Arrays.asList(1, 2, 3, 4)));
-    List uint32List = Arrays.asList(0, 1, 4294967295L);
-    bounded_seq.setUint32Values(uint32List);
-    assertEquals(uint32List, bounded_seq.getUint32Values());
-    List uint32ListShort = Arrays.asList(4294967295L, 1);
-    bounded_seq.setUint32Values(uint32ListShort);
-    assertEquals(uint32ListShort, bounded_seq.getUint32Values());
+    bounded_seq.setUint32Values(fixture.uint32List);
+    assertArrayEquals(fixture.uint32Arr, bounded_seq.getUint32Values());
+    assertEquals(fixture.uint32List, bounded_seq.getUint32ValuesAsList());
+    bounded_seq.setUint32Values(fixture.uint32ListShort);
+    assertArrayEquals(fixture.uint32ArrShort, bounded_seq.getUint32Values());
+    assertEquals(fixture.uint32ListShort, bounded_seq.getUint32ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setUint32Values(new int[]{1, 2, 3, 4}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setUint32Values(Arrays.asList(1, 2, 3, 4)));
-    List int64List = Arrays.asList(0, -9223372036854775808L, 9223372036854775807L);
-    bounded_seq.setInt64Values(int64List);
-    assertEquals(int64List, bounded_seq.getInt64Values());
-    List int64ListShort = Arrays.asList(0, -9223372036854775808L, 9223372036854775807L);
-    bounded_seq.setInt64Values(int64ListShort);
-    assertEquals(int64ListShort, bounded_seq.getInt64Values());
+    bounded_seq.setInt64Values(fixture.int64List);
+    assertArrayEquals(fixture.int64Arr, bounded_seq.getInt64Values());
+    assertEquals(fixture.int64List, bounded_seq.getInt64ValuesAsList());
+    bounded_seq.setInt64Values(fixture.int64ListShort);
+    assertArrayEquals(fixture.int64ArrShort, bounded_seq.getInt64Values());
+    assertEquals(fixture.int64ListShort, bounded_seq.getInt64ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setInt64Values(new long[]{1L, 2L, 3L, 4L}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setInt64Values(Arrays.asList(1L, 2L, 3L, 4L)));
-    List uint64List = Arrays.asList(0, 1, -1);
-    bounded_seq.setUint64Values(uint64List);
-    assertEquals(uint64List, bounded_seq.getUint64Values());
-    List uint64ListShort = Arrays.asList(0, 1, -1);
-    bounded_seq.setUint64Values(uint64ListShort);
-    assertEquals(uint64ListShort, bounded_seq.getUint64Values());
+    bounded_seq.setUint64Values(fixture.uint64List);
+    assertArrayEquals(fixture.uint64Arr, bounded_seq.getUint64Values());
+    assertEquals(fixture.uint64List, bounded_seq.getUint64ValuesAsList());
+    bounded_seq.setUint64Values(fixture.uint64ListShort);
+    assertArrayEquals(fixture.uint64ArrShort, bounded_seq.getUint64Values());
+    assertEquals(fixture.uint64ListShort, bounded_seq.getUint64ValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setUint64Values(new long[]{1L, 2L, 3L, 4L}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setUint64Values(Arrays.asList(1L, 2L, 3L, 4L)));
 
     // Test setting/getting fixed length bounded_seq of strings
-    List stringList = Arrays.asList("", "min value", "max_value");
-    bounded_seq.setStringValues(stringList);
-    assertEquals(stringList, bounded_seq.getStringValues());
-    List stringListShort = Arrays.asList("max_value", "");
-    bounded_seq.setStringValues(stringListShort);
-    assertEquals(stringListShort, bounded_seq.getStringValues());
+    bounded_seq.setStringValues(fixture.stringList);
+    assertArrayEquals(fixture.stringArr, bounded_seq.getStringValues());
+    assertEquals(fixture.stringList, bounded_seq.getStringValuesAsList());
+    bounded_seq.setStringValues(fixture.stringListShort);
+    assertArrayEquals(fixture.stringArrShort, bounded_seq.getStringValues());
+    assertEquals(fixture.stringListShort, bounded_seq.getStringValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setStringValues(new String[]{"too", "many", "values", "!"}));
     assertThrows(IllegalArgumentException.class,
       () -> bounded_seq.setStringValues(Arrays.asList("too", "many", "values", "!")));
 
     // Test setting/getting fixed length bounded_seq of nested types
-    rosidl_generator_java.msg.BasicTypes basicTypes = new rosidl_generator_java.msg.BasicTypes();
-    List basicTypesList = Arrays.asList(
-        new rosidl_generator_java.msg.BasicTypes[] {basicTypes, basicTypes, basicTypes});
-    bounded_seq.setBasicTypesValues(basicTypesList);
-    assertEquals(basicTypesList, bounded_seq.getBasicTypesValues());
-    List basicTypesListShort = Arrays.asList(
-        new rosidl_generator_java.msg.BasicTypes[] {basicTypes});
-    bounded_seq.setBasicTypesValues(basicTypesListShort);
-    assertEquals(basicTypesListShort, bounded_seq.getBasicTypesValues());
+    bounded_seq.setBasicTypesValues(fixture.basicTypesList);
+    assertArrayEquals(fixture.basicTypesArr, bounded_seq.getBasicTypesValues());
+    assertEquals(fixture.basicTypesList, bounded_seq.getBasicTypesValuesAsList());
+    bounded_seq.setBasicTypesValues(fixture.basicTypesListShort);
+    assertArrayEquals(fixture.basicTypesArrShort, bounded_seq.getBasicTypesValues());
+    assertEquals(fixture.basicTypesListShort, bounded_seq.getBasicTypesValuesAsList());
     assertThrows(IllegalArgumentException.class,
-      () -> bounded_seq.setBasicTypesValues(
-          Arrays.asList(new rosidl_generator_java.msg.BasicTypes[] {basicTypes, basicTypes, basicTypes, basicTypes})));
-    rosidl_generator_java.msg.Constants constants = new rosidl_generator_java.msg.Constants();
-    List constantsList = Arrays.asList(
-        new rosidl_generator_java.msg.Constants[] {constants, constants, constants});
-    bounded_seq.setConstantsValues(constantsList);
-    assertEquals(constantsList, bounded_seq.getConstantsValues());
-    List constantsListShort = Arrays.asList(
-        new rosidl_generator_java.msg.Constants[] {constants});
-    bounded_seq.setConstantsValues(constantsListShort);
-    assertEquals(constantsListShort, bounded_seq.getConstantsValues());
+      () -> bounded_seq.setBasicTypesValues(fixture.basicTypesArrLong));
     assertThrows(IllegalArgumentException.class,
-      () -> bounded_seq.setConstantsValues(
-          Arrays.asList(new rosidl_generator_java.msg.Constants[] {constants, constants, constants, constants})));
-    rosidl_generator_java.msg.Defaults defaults = new rosidl_generator_java.msg.Defaults();
-    List defaultsList = Arrays.asList(
-        new rosidl_generator_java.msg.Defaults[] {defaults, defaults, defaults});
-    bounded_seq.setDefaultsValues(defaultsList);
-    assertEquals(defaultsList, bounded_seq.getDefaultsValues());
-    List defaultsListShort = Arrays.asList(
-        new rosidl_generator_java.msg.Defaults[] {defaults, defaults, defaults});
-    bounded_seq.setDefaultsValues(defaultsListShort);
-    assertEquals(defaultsListShort, bounded_seq.getDefaultsValues());
+      () -> bounded_seq.setBasicTypesValues(fixture.basicTypesListLong));
+    bounded_seq.setConstantsValues(fixture.constantsList);
+    assertArrayEquals(fixture.constantsArr, bounded_seq.getConstantsValues());
+    assertEquals(fixture.constantsList, bounded_seq.getConstantsValuesAsList());
+    bounded_seq.setConstantsValues(fixture.constantsListShort);
+    assertArrayEquals(fixture.constantsArrShort, bounded_seq.getConstantsValues());
+    assertEquals(fixture.constantsListShort, bounded_seq.getConstantsValuesAsList());
     assertThrows(IllegalArgumentException.class,
-      () -> bounded_seq.setDefaultsValues(
-          Arrays.asList(new rosidl_generator_java.msg.Defaults[] {defaults, defaults, defaults, defaults})));
+      () -> bounded_seq.setConstantsValues(fixture.constantsArrLong));
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setConstantsValues(fixture.constantsListLong));
+    bounded_seq.setDefaultsValues(fixture.defaultsList);
+    assertArrayEquals(fixture.defaultsArr, bounded_seq.getDefaultsValues());
+    assertEquals(fixture.defaultsList, bounded_seq.getDefaultsValuesAsList());
+    bounded_seq.setDefaultsValues(fixture.defaultsListShort);
+    assertArrayEquals(fixture.defaultsArrShort, bounded_seq.getDefaultsValues());
+    assertEquals(fixture.defaultsListShort, bounded_seq.getDefaultsValuesAsList());
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setDefaultsValues(fixture.defaultsArrLong));
+    assertThrows(IllegalArgumentException.class,
+      () -> bounded_seq.setDefaultsValues(fixture.defaultsListLong));
 
     assertEquals(42, bounded_seq.getAlignmentCheck());
   }
@@ -475,72 +615,67 @@ public class InterfacesTest {
   @Test
   public final void testUnboundedSequences() {
     rosidl_generator_java.msg.UnboundedSequences unbounded_seq = new rosidl_generator_java.msg.UnboundedSequences();
+    ListFixtureData fixture = new ListFixtureData();
 
     // This value should not change and is asserted at end of test
     unbounded_seq.setAlignmentCheck(42);
 
     // Test setting/getting fixed length unbounded_seq of primitive types
-    List boolList = Arrays.asList(true, false, true);
-    unbounded_seq.setBoolValues(boolList);
-    assertEquals(boolList, unbounded_seq.getBoolValues());
-    List byteList = Arrays.asList((byte) 0, (byte) 1, (byte) 255);
-    unbounded_seq.setByteValues(byteList);
-    assertEquals(byteList, unbounded_seq.getByteValues());
-    List charList = Arrays.asList(' ', 'a', 'Z');
-    unbounded_seq.setCharValues(charList);
-    assertEquals(charList, unbounded_seq.getCharValues());
-    List float32List = Arrays.asList(0.0f, -1.125f, 1.125f);
-    unbounded_seq.setFloat32Values(float32List);
-    assertEquals(float32List, unbounded_seq.getFloat32Values());
-    List float64List = Arrays.asList(0.0f, -3.1415, 3.1415);
-    unbounded_seq.setFloat64Values(float64List);
-    assertEquals(float64List, unbounded_seq.getFloat64Values());
-    List int8List = Arrays.asList(0, -128, 127);
-    unbounded_seq.setInt8Values(int8List);
-    assertEquals(int8List, unbounded_seq.getInt8Values());
-    List uint8List = Arrays.asList(0, 1, 255);
-    unbounded_seq.setUint8Values(uint8List);
-    assertEquals(uint8List, unbounded_seq.getUint8Values());
-    List int16List = Arrays.asList(0, -32768, 32767);
-    unbounded_seq.setInt16Values(int16List);
-    assertEquals(int16List, unbounded_seq.getInt16Values());
-    List uint16List = Arrays.asList(0, 1, 65535);
-    unbounded_seq.setUint16Values(uint16List);
-    assertEquals(uint16List, unbounded_seq.getUint16Values());
-    List int32List = Arrays.asList(0, -2147483648, 2147483647);
-    unbounded_seq.setInt32Values(int32List);
-    assertEquals(int32List, unbounded_seq.getInt32Values());
-    List uint32List = Arrays.asList(0, 1, 4294967295L);
-    unbounded_seq.setUint32Values(uint32List);
-    assertEquals(uint32List, unbounded_seq.getUint32Values());
-    List int64List = Arrays.asList(0, -9223372036854775808L, 9223372036854775807L);
-    unbounded_seq.setInt64Values(int64List);
-    assertEquals(int64List, unbounded_seq.getInt64Values());
-    List uint64List = Arrays.asList(0, 1, -1);
-    unbounded_seq.setUint64Values(uint64List);
-    assertEquals(uint64List, unbounded_seq.getUint64Values());
+    unbounded_seq.setBoolValues(fixture.boolList);
+    assertArrayEquals(fixture.boolArr, unbounded_seq.getBoolValues());
+    assertEquals(fixture.boolList, unbounded_seq.getBoolValuesAsList());
+    unbounded_seq.setByteValues(fixture.byteList);
+    assertArrayEquals(fixture.byteArr, unbounded_seq.getByteValues());
+    assertEquals(fixture.byteList, unbounded_seq.getByteValuesAsList());
+    unbounded_seq.setCharValues(fixture.charList);
+    assertArrayEquals(fixture.charArr, unbounded_seq.getCharValues());
+    assertEquals(fixture.charList, unbounded_seq.getCharValuesAsList());
+    unbounded_seq.setFloat32Values(fixture.float32List);
+    assertTrue(Arrays.equals(fixture.float32Arr, unbounded_seq.getFloat32Values()));
+    assertEquals(fixture.float32List, unbounded_seq.getFloat32ValuesAsList());
+    unbounded_seq.setFloat64Values(fixture.float64List);
+    assertTrue(Arrays.equals(fixture.float64Arr, unbounded_seq.getFloat64Values()));
+    assertEquals(fixture.float64List, unbounded_seq.getFloat64ValuesAsList());
+    unbounded_seq.setInt8Values(fixture.int8List);
+    assertArrayEquals(fixture.int8Arr, unbounded_seq.getInt8Values());
+    assertEquals(fixture.int8List, unbounded_seq.getInt8ValuesAsList());
+    unbounded_seq.setUint8Values(fixture.uint8List);
+    assertArrayEquals(fixture.uint8Arr, unbounded_seq.getUint8Values());
+    assertEquals(fixture.uint8List, unbounded_seq.getUint8ValuesAsList());
+    unbounded_seq.setInt16Values(fixture.int16List);
+    assertTrue(Arrays.equals(fixture.int16Arr, unbounded_seq.getInt16Values()));
+    assertEquals(fixture.int16List, unbounded_seq.getInt16ValuesAsList());
+    unbounded_seq.setUint16Values(fixture.uint16List);
+    assertTrue(Arrays.equals(fixture.uint16Arr, unbounded_seq.getUint16Values()));
+    assertEquals(fixture.uint16List, unbounded_seq.getUint16ValuesAsList());
+    unbounded_seq.setInt32Values(fixture.int32List);
+    assertArrayEquals(fixture.int32Arr, unbounded_seq.getInt32Values());
+    assertEquals(fixture.int32List, unbounded_seq.getInt32ValuesAsList());
+    unbounded_seq.setUint32Values(fixture.uint32List);
+    assertArrayEquals(fixture.uint32Arr, unbounded_seq.getUint32Values());
+    assertEquals(fixture.uint32List, unbounded_seq.getUint32ValuesAsList());
+    unbounded_seq.setInt64Values(fixture.int64List);
+    assertArrayEquals(fixture.int64Arr, unbounded_seq.getInt64Values());
+    assertEquals(fixture.int64List, unbounded_seq.getInt64ValuesAsList());
+    unbounded_seq.setUint64Values(fixture.uint64List);
+    assertArrayEquals(fixture.uint64Arr, unbounded_seq.getUint64Values());
+    assertEquals(fixture.uint64List, unbounded_seq.getUint64ValuesAsList());
 
     // Test setting/getting fixed length unbounded_seq of strings
-    List stringList = Arrays.asList("", "min value", "max_value");
-    unbounded_seq.setStringValues(stringList);
-    assertEquals(stringList, unbounded_seq.getStringValues());
+    unbounded_seq.setStringValues(fixture.stringList);
+    assertArrayEquals(fixture.stringArr, unbounded_seq.getStringValues());
+    assertEquals(fixture.stringList, unbounded_seq.getStringValuesAsList());
 
     // Test setting/getting fixed length unbounded_seq of nested types
-    rosidl_generator_java.msg.BasicTypes basicTypes = new rosidl_generator_java.msg.BasicTypes();
-    List basicTypesList = Arrays.asList(
-        new rosidl_generator_java.msg.BasicTypes[] {basicTypes, basicTypes, basicTypes});
-    unbounded_seq.setBasicTypesValues(basicTypesList);
-    assertEquals(basicTypesList, unbounded_seq.getBasicTypesValues());
-    rosidl_generator_java.msg.Constants constants = new rosidl_generator_java.msg.Constants();
-    List constantsList = Arrays.asList(
-        new rosidl_generator_java.msg.Constants[] {constants, constants, constants});
-    unbounded_seq.setConstantsValues(constantsList);
-    assertEquals(constantsList, unbounded_seq.getConstantsValues());
-    rosidl_generator_java.msg.Defaults defaults = new rosidl_generator_java.msg.Defaults();
-    List defaultsList = Arrays.asList(
-        new rosidl_generator_java.msg.Defaults[] {defaults, defaults, defaults});
-    unbounded_seq.setDefaultsValues(defaultsList);
-    assertEquals(defaultsList, unbounded_seq.getDefaultsValues());
+    unbounded_seq.setBasicTypesValues(fixture.basicTypesList);
+    assertArrayEquals(fixture.basicTypesArr, unbounded_seq.getBasicTypesValues());
+    assertEquals(fixture.basicTypesList, unbounded_seq.getBasicTypesValuesAsList());
+    unbounded_seq.setConstantsValues(fixture.constantsList);
+    assertArrayEquals(fixture.constantsArr, unbounded_seq.getConstantsValues());
+    assertEquals(fixture.constantsList, unbounded_seq.getConstantsValuesAsList());
+    unbounded_seq.setDefaultsValues(fixture.defaultsList);
+    assertArrayEquals(fixture.defaultsArr, unbounded_seq.getDefaultsValues());
+    assertEquals(fixture.defaultsList, unbounded_seq.getDefaultsValuesAsList());
 
     assertEquals(42, unbounded_seq.getAlignmentCheck());
   }


### PR DESCRIPTION
This builds on #151. 

Switching from `java.util.List` to arrays significantly improves performance when converting from C to Java types.
Though, for some applications it is still nice to use a list so I've added a convenience methods for getting and setting the value as a `List` (df08714). I've still opted for having the default getter method return an array type to encourage users to use arrays, since converting to a `List` is not very efficient.

