### PR TITLE
Simplify access to service callback

### DIFF
--- a/rcljava/src/main/java/org/ros2/rcljava/service/ServiceImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/service/ServiceImpl.java
@@ -100,9 +100,7 @@ public class ServiceImpl<T extends ServiceDefinition> implements Service<T> {
 
   public void executeCallback(
       RMWRequestId rmwRequestId, MessageDefinition request, MessageDefinition response) {
-    TriConsumer<RMWRequestId, MessageDefinition, MessageDefinition> callback =
-        ((ServiceImpl) this).callback;
-
+    TriConsumer callback = this.callback;
     callback.accept(rmwRequestId, request, response);
   }
 


### PR DESCRIPTION
This also works around the problem of assigning to an 'incompatible type', but looks much cleaner.