### PR TITLE
Avoid duplicated github actions checks for pull-request/push events

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,13 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+
+
 
 jobs:
   build_and_test:


### PR DESCRIPTION
* Avoid duplicated github actions checks for pull-request/push events.
* Only trigger CI on a subset of pull request events: opened, reopened and synchronized.